### PR TITLE
WebAssembly (WASI) support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,9 @@ LDFLAGS = -L/usr/local/lib -lm
 ifdef ISOCLINE
 CFLAGS += -DUSE_ISOCLINE=1
 else
+ifndef WASI
 LDFLAGS += -lreadline
+endif
 endif
 
 ifndef NOFFI
@@ -32,6 +34,11 @@ endif
 ifdef LTO
 CFLAGS += -flto=$(LTO)
 LDFLAGS += -flto=$(LTO)
+endif
+
+ifdef WASI
+CFLAGS += -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -O0
+LDFLAGS += -lwasi-emulated-mman -lwasi-emulated-signal
 endif
 
 SRCOBJECTS = tpl.o \

--- a/src/functions.c
+++ b/src/functions.c
@@ -693,10 +693,12 @@ static bool fn_iso_truncate_1(query *q)
 	if (is_float(&p1)) {
 		q->accum.val_int = (pl_int_t)p1.val_float;
 
+#ifdef FE_INVALID
 		if (fetestexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW)) {
 			mp_int_set_double(&q->tmp_ival, p1.val_float);
 			SET_ACCUM();
 		} else
+#endif
 			q->accum.tag = TAG_INTEGER;
 	} else if (is_variable(&p1)) {
 		return throw_error(q, &p1, q->st.curr_frame, "instantiation_error", "not_sufficiently_instantiated");
@@ -718,17 +720,23 @@ static bool fn_iso_round_1(query *q)
 	if (is_float(&p1)) {
 		double f = fabs(p1.val_float);
 
+#ifdef FE_UPWARD
 		if ((f - floor(f)) > 0.5)
 			fesetround(FE_TONEAREST);
 		else
 			fesetround(FE_UPWARD);
+#else
+		fesetround(FE_TONEAREST);
+#endif
 
 		q->accum.val_int = llrint(p1.val_float);
 
+#ifdef FE_INVALID
 		if (fetestexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW)) {
 			mp_int_set_double(&q->tmp_ival, p1.val_float);
 			SET_ACCUM();
 		} else
+#endif
 			q->accum.tag = TAG_INTEGER;
 	} else if (is_variable(&p1)) {
 		return throw_error(q, &p1, q->st.curr_frame, "instantiation_error", "not_sufficiently_instantiated");
@@ -750,10 +758,12 @@ static bool fn_iso_ceiling_1(query *q)
 	if (is_float(&p1)) {
 		q->accum.val_int = (pl_int_t)ceil(p1.val_float);
 
+#ifdef FE_INVALID
 		if (fetestexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW)) {
 			mp_int_set_double(&q->tmp_ival, p1.val_float);
 			SET_ACCUM();
 		} else
+#endif
 			q->accum.tag = TAG_INTEGER;
 	} else if (is_variable(&p1)) {
 		return throw_error(q, &p1, q->st.curr_frame, "instantiation_error", "not_sufficiently_instantiated");
@@ -819,10 +829,12 @@ static bool fn_iso_floor_1(query *q)
 	if (is_float(&p1)) {
 		q->accum.val_int = (pl_int_t)floor(p1.val_float);
 
+#ifdef FE_INVALID
 		if (fetestexcept(FE_INVALID | FE_DIVBYZERO | FE_OVERFLOW | FE_UNDERFLOW)) {
 			mp_int_set_double(&q->tmp_ival, p1.val_float);
 			SET_ACCUM();
 		} else
+#endif
 			q->accum.tag = TAG_INTEGER;
 	} else if (is_variable(&p1)) {
 		return throw_error(q, &p1, q->st.curr_frame, "instantiation_error", "not_sufficiently_instantiated");

--- a/src/internal.h
+++ b/src/internal.h
@@ -43,7 +43,7 @@ typedef uint32_t pl_idx_t;
 #include "cdebug.h"
 #include "imath/imath.h"
 
-#ifdef _WIN32
+#if defined(_WIN32) || defined(__wasi__)
 char *realpath(const char *path, char resolved_path[PATH_MAX]);
 #endif
 

--- a/src/predicates.c
+++ b/src/predicates.c
@@ -4841,7 +4841,11 @@ static bool fn_pid_1(query *q)
 {
 	GET_FIRST_ARG(p1,variable);
 	cell tmp;
+#ifndef __wasi__
 	make_int(&tmp, getpid());
+#else
+	make_int(&tmp, 42);
+#endif
 	return unify(q, p1, p1_ctx, &tmp, q->st.curr_frame);
 }
 
@@ -4910,6 +4914,7 @@ static bool fn_date_time_6(query *q)
 	return true;
 }
 
+#ifndef __wasi__
 static bool fn_shell_1(query *q)
 {
 	GET_FIRST_ARG(p1,atom);
@@ -4929,6 +4934,17 @@ static bool fn_shell_2(query *q)
 	make_int(&tmp, status);
 	return unify(q, p2, p2_ctx, &tmp, q->st.curr_frame);
 }
+#else
+static bool fn_shell_1(query *q)
+{
+	return false;
+}
+
+static bool fn_shell_2(query *q)
+{
+	return false;
+}
+#endif
 
 static bool fn_format_2(query *q)
 {
@@ -6653,7 +6669,7 @@ static bool fn_sys_register_term_1(query *q)
 
 static bool fn_sys_alarm_1(query *q)
 {
-#ifdef _WIN32
+#if defined(_WIN32) || !defined(ITIMER_REAL)
 	return false;
 #else
 	GET_FIRST_ARG(p1,number);

--- a/src/prolog.c
+++ b/src/prolog.c
@@ -141,7 +141,12 @@ static void g_destroy()
 	free(g_tpl_lib);
 }
 
-static void keyvalfree(const void *key, const void *val)
+static void keyfree(const void *key, const void *val, const void *p)
+{
+	free((void*)key);
+}
+
+static void keyvalfree(const void *key, const void *val, const void *p)
 {
 	free((void*)key);
 	free((void*)val);
@@ -333,7 +338,7 @@ prolog *pl_create()
 	if (!pl->pool) return NULL;
 	bool error = false;
 
-	CHECK_SENTINEL(pl->symtab = map_create((void*)fake_strcmp, (void*)free, NULL), NULL);
+	CHECK_SENTINEL(pl->symtab = map_create((void*)fake_strcmp, (void*)keyfree, NULL), NULL);
 	CHECK_SENTINEL(pl->keyval = map_create((void*)fake_strcmp, (void*)keyvalfree, NULL), NULL);
 	map_allow_dups(pl->symtab, false);
 	map_allow_dups(pl->keyval, false);

--- a/src/streams.c
+++ b/src/streams.c
@@ -29,6 +29,30 @@
 #include "query.h"
 #include "utf8.h"
 
+#ifdef __wasi__
+char *realpath(const char *path, char resolved_path[PATH_MAX])
+{
+	if (!path) {
+		errno = EINVAL;
+		return NULL;
+	}
+
+	struct stat st = {0};
+	if (stat(path, &st)) {
+		// errno set by stat
+		return NULL;
+	}
+
+	if (!resolved_path) {
+		resolved_path = malloc(PATH_MAX);
+		ensure(resolved_path);
+	}
+
+	strcpy(resolved_path, path);
+	return resolved_path;
+}
+#endif
+
 #ifdef _WIN32
 #include <windows.h>
 
@@ -562,7 +586,7 @@ void convert_path(char *filename)
 	}
 }
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
 static bool fn_popen_4(query *q)
 {
 	GET_FIRST_ARG(p1,atom);
@@ -5421,7 +5445,7 @@ builtins g_files_bifs[] =
 	{"bwrite", 2, fn_bwrite_2, "+stream,-string", false, BLAH},
 
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
 	{"popen", 4, fn_popen_4, "+atom,+atom,-stream,+list", false, BLAH},
 #endif
 

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -38,7 +38,9 @@ int check_interrupt(query *q)
 
 		fflush(stdout);
 		int ch = history_getch();
+#ifndef __wasi__
 		printf("%c\n", ch);
+#endif
 
 		if (ch == 'h') {
 			printf("Action (a)ll, (e)nd, e(x)it, (r)etry, (c)ontinue, (t)race, cree(p): ");
@@ -59,8 +61,10 @@ int check_interrupt(query *q)
 			break;
 		}
 
+#ifndef __wasi__
 		if (ch == '\n')
 			return -1;
+#endif
 
 		if (ch == 'e') {
 			q->abort = true;
@@ -120,6 +124,10 @@ bool check_redo(query *q)
 			continue;
 		}
 
+#ifdef __wasi__
+	printf(" ");
+#endif
+
 		if (ch == 'a') {
 			printf(" ");
 			fflush(stdout);
@@ -139,7 +147,12 @@ bool check_redo(query *q)
 			break;
 		}
 
+#ifndef __wasi__
 		if ((ch == '\n') || (ch == 'e')) {
+#else
+		// WASI always sends buffered input with a linebreak, so use '.' instead
+		if ((ch == '.') || (ch == 'e')) {
+#endif
 			//printf(";  ... .\n");
 			printf("  ... .\n");
 			q->pl->did_dump_vars = true;

--- a/src/unify.c
+++ b/src/unify.c
@@ -620,7 +620,7 @@ cell *skip_max_list(query *q, cell *head, pl_idx_t *head_ctx, pl_int_t max, pl_i
 	pl_int_t offset = 0;
 #endif
 
-LOOP:
+LOOP: ;
 
 #if 0
 	if (is_string(head)) {

--- a/tpl.c
+++ b/tpl.c
@@ -20,7 +20,9 @@
 #else
 #include <sys/stat.h>
 #include <sys/types.h>
+#ifndef __wasi__
 #include <sys/wait.h>
+#endif
 #define msleep(ms)                                                     \
 {                                                                      \
 	struct timespec tv;                                                \
@@ -36,6 +38,7 @@ void sigfn(int s)
 	g_tpl_interrupt = s;
 }
 
+#ifndef __wasi__
 static int daemonize(int argc, char *argv[])
 {
 	char path[1024];
@@ -132,6 +135,7 @@ static int daemonize(int argc, char *argv[])
 	return 1;
 #endif
 }
+#endif
 
 int main(int ac, char *av[])
 {
@@ -182,6 +186,7 @@ int main(int ac, char *av[])
 			daemon = 1;
 	}
 
+#ifndef __wasi__
 	if (daemon) {
 		if (!daemonize(ac, av)) {
 			pl_destroy(pl);
@@ -193,8 +198,9 @@ int main(int ac, char *av[])
 		signal(SIGALRM, &sigfn);
 #endif
 	}
+#endif
 
-#ifndef _WIN32
+#if !defined(_WIN32) && !defined(__wasi__)
 	signal(SIGPIPE, SIG_IGN);
 #endif
 	const char *goal = NULL;


### PR DESCRIPTION
This PR adds support for [WASI](https://wasi.dev/)/WebAssembly (see: #618)
You can play around with it in your browser here: https://wapm.io/guregu/trealla

This is my first time contributing to a C project so apologies if I did anything dumb.
Also, the REPL should look pretty good now. There is a minor issue where it prints the prompt twice after finishing a query with multiple choicepoints, but things are at least aligned nicely.

## Mystery
Without `-O0`, the optimizer is breaking something related to the library script embedding. I get some weird syntax errors on startup with optimization enabled. I'm not sure if this is a WASI compiler bug or what. I need disassemble it later and try to figure out what's going on. WASM runtimes have JIT so maybe it's not a big deal?

## Major differences
From what I can tell, WASI is missing this functionality:
- fancy floating point stuff (FE_UPWARD, FE_INVALID, etc.)
- terminal I/O (termios.h) 

Where possible, I tried to ifdef these out based on their API symbols so they can be supported easily in the future when WASI catches up.

## Build
For future reference, here's how I built it:
- [WASI-SDK v15](https://github.com/WebAssembly/wasi-sdk)
- `WASI=1 NOFFI=1 NOSSL=1 CC=/opt/wasi-sdk/bin/clang make`

## Tests
Tests are looking pretty good, failures seem to be unsupported stuff.

```
============
TEST SUMMARY
============
Failed: 4
Succeeded: 143
```
### Failures
- test056: crypto not supported
- test081: FE_UPWARD not supported
- test585: FE_UPWARD not supported?
- test605: running out of memory here, probably wasm runtime configuration issue