### PR TITLE
Automatically build/test & release to WAPM

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,84 @@
+  name: Build
+
+  on:
+    create:
+      tags:
+    push:
+      branches:
+        - main
+    pull_request:
+
+  jobs:
+    build:
+      name: Native
+      runs-on: ${{ matrix.os }}
+      strategy:
+        fail-fast: false
+        matrix:
+          os:
+            - ubuntu-latest
+#            - macos-latest (TODO: currently broken, needs OpenSSL library path fixed)
+      steps:
+        - uses: actions/checkout@v1
+        - name: Install deps (Linux)
+          run: |
+            sudo apt-get install libreadline-dev xxd libffi-dev libssl-dev
+          if: matrix.os == 'ubuntu-latest'
+        - name: Install deps (macOS)
+          run: |
+            brew install readline vim libffi openssl make
+            echo "$(brew --prefix)/opt/make/libexec/gnubin" >> $GITHUB_PATH
+          if: matrix.os == 'macos-latest'
+        - name: Build
+          run: make release
+        - name: Test
+          run: make test
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v1
+          with:
+            name: ${{ format( 'tpl-{0}', matrix.os) }}
+            path: tpl
+
+    # Roughly matches https://github.com/WebAssembly/wasi-sdk#install
+    wasm:
+      name: WebAssembly
+      runs-on: ubuntu-latest
+      env:
+        WASI_VERSION: 15
+        BINARYEN_VERSION: 109
+        WAPM_REGISTRY_TOKEN: ${{ secrets.WAPM_REGISTRY_TOKEN }}
+      steps:
+        - uses: actions/checkout@v1
+        - name: Set environment (1/3)
+          run: |
+            echo "WASI_VERSION_FULL=${WASI_VERSION}.0" >> $GITHUB_ENV
+            echo "RELEASE_VERSION=`git tag --points-at HEAD | sed 's/^v//'`" >> $GITHUB_ENV
+        - name: Set environment (2/3)
+          run: |
+            echo "WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}" >> $GITHUB_ENV
+        - name: Set environment (3/3)
+          run: |
+            echo "WASI_CC=${WASI_SDK_PATH}/bin/clang --sysroot=${WASI_SDK_PATH}/share/wasi-sysroot" >> $GITHUB_ENV
+        - name: Install WASI SDK
+          run: |
+            wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
+            tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
+        - name: Install Binaryen
+          run: brew install binaryen
+        - name: Build
+          run: |
+            make clean
+            make wasm
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v1
+          with:
+            name: tpl.wasm
+            path: tpl.wasm
+        - name: Release on WAPM
+          run: |
+            curl https://get.wasmer.io -sSfL | sh
+            source /home/runner/.wasmer/wasmer.sh
+            wapm login $WAPM_REGISTRY_TOKEN
+            sed -i "s/__RELEASE_VERSION__/$RELEASE_VERSION/" wapm.toml
+            wapm publish
+          if: ${{ env.WAPM_REGISTRY_TOKEN != '' && env.RELEASE_VERSION != '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -65,20 +65,25 @@
             tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
         - name: Install Binaryen
           run: brew install binaryen
+        - name: Setup Wasmer
+          uses: wasmerio/setup-wasmer@v1
         - name: Build
           run: |
             make clean
             make wasm
+        - name: Test
+          run: |
+            echo 'wasmer --dir . tpl.wasm -- $@' > tpl
+            chmod +x tpl
+            make test
         - name: Upload artifacts
           uses: actions/upload-artifact@v1
           with:
             name: tpl.wasm
             path: tpl.wasm
-        - name: Release on WAPM
+        - name: Publish on WAPM
           run: |
-            curl https://get.wasmer.io -sSfL | sh
-            source /home/runner/.wasmer/wasmer.sh
-            wapm login $WAPM_REGISTRY_TOKEN
             sed -i "s/__RELEASE_VERSION__/$RELEASE_VERSION/" wapm.toml
+            wapm login $WAPM_REGISTRY_TOKEN
             wapm publish
           if: ${{ env.WAPM_REGISTRY_TOKEN != '' && env.RELEASE_VERSION != '' }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,7 +17,7 @@
         matrix:
           os:
             - ubuntu-latest
-#            - macos-latest (TODO: currently broken, needs OpenSSL library path fixed)
+            - macos-latest
       steps:
         - uses: actions/checkout@v1
         - name: Install deps (Linux)

--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ endif
 endif
 
 ifndef NOFFI
-CFLAGS += -DUSE_FFI=1 -I/usr/local/OPT/LIBFFI/include
+CFLAGS += -DUSE_FFI=1 -I/usr/local/opt/libffi/include
 LDFLAGS += -lffi -ldl
 endif
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ LDFLAGS += -lffi -ldl
 endif
 
 ifndef NOSSL
-CFLAGS += -DUSE_OPENSSL=1
+CFLAGS += -DUSE_OPENSSL=1 -I/usr/local/opt/openssl/include
 LDFLAGS += -L/usr/local/opt/openssl/lib -lssl -lcrypto
 endif
 

--- a/wapm.toml
+++ b/wapm.toml
@@ -1,0 +1,19 @@
+[package]
+name = "guregu/trealla"
+version = "__RELEASE_VERSION__"
+description = "Trealla Prolog"
+license = "MIT"
+repository = "https://github.com/trealla-prolog/trealla"
+wasmer-extra-flags = "--enable-bulk-memory"
+
+[[module]]
+name = "tpl"
+source = "tpl.wasm"
+abi = "wasi"
+
+[module.interfaces]
+wasi = "0.1.0-unstable"
+
+[[command]]
+name = "tpl"
+module = "tpl"

--- a/wapm.toml
+++ b/wapm.toml
@@ -1,5 +1,5 @@
 [package]
-name = "guregu/trealla"
+name = "trealla/trealla"
 version = "__RELEASE_VERSION__"
 description = "Trealla Prolog"
 license = "MIT"


### PR DESCRIPTION
This adds a GitHub action workflow that gets triggered on tag creation, pushes to main, and PRs.

For the native version it builds tpl and runs the tests, then uploads an artifact to GitHub's artifact thing (this should be free for public projects). I think we could use this to provide binary releases later on but not sure how to do it yet.

For the WebAssembly version it builds, optimizes, uploads the artifact, and publishes it to https://wapm.io. Doesn't run the tests yet, need to get it to skip the unpassable ones for WASM build.

To get WAPM publishing working:
1. you'll need to register on https://wapm.io and grab an access token
2. configure a secret in the repository settings called `WAPM_REGISTRY_TOKEN` with it
3. edit `wapm.toml`'s name to match the username you used for WAPM (I just put trealla there assuming nobody has registered it yet 🙂). So if you use the username `trealla-prolog` change it to `name = "trealla-prolog/trealla"`. (Username/packagename format)

It should gracefully degrade and ignore the publishing part if it's unconfigured.
If you'd like me to set it up instead, I'd be happy to do so. I got it working in a fork.
WAPM is kind of like NPM and manages WASM binaries for you, so it's handy for projects like my PHP one that rely on the Trealla WASM binary.

BTW, we got a shout in [this blog article](https://wasmer.io/posts/wasm-as-universal-binary-format-part-2-wapm) using Trealla as an example, pretty cool.