### PR TITLE
Fix WASI readline's error handling

### DIFF
--- a/src/history.c
+++ b/src/history.c
@@ -196,7 +196,7 @@ char *history_readline_eol(const char *prompt, char eol)
 
 	size_t len = 0;
 	char *line = NULL;
-	if (!(getline(&line, &len, stdin)))
+	if (getline(&line, &len, stdin) <= 0)
 		return NULL;
 
 	return line;


### PR DESCRIPTION
Fixes an error checking mistake in WASI's readline (whoops).
-1 return value here was throwing the WASM toplevel into an infinite loop given a finite stdin.