### PR TITLE
Fix typo in abnf library

### DIFF
--- a/src/library.c
+++ b/src/library.c
@@ -50,7 +50,7 @@ extern unsigned char library_abnf_pl[];
 extern unsigned int library_abnf_pl_len;
 
 library g_libs[] = {
-	 {"apply", library_abnf_pl, &library_abnf_pl_len},
+	 {"abnf", library_abnf_pl, &library_abnf_pl_len},
 	 {"apply", library_apply_pl, &library_apply_pl_len},
 	 {"assoc", library_assoc_pl, &library_assoc_pl_len},
 	 {"atts", library_atts_pl, &library_atts_pl_len},


### PR DESCRIPTION
Syntax error on startup otherwise (I think).