### PR TITLE
Fix realpath for WASM builds

### DIFF
--- a/src/streams.c
+++ b/src/streams.c
@@ -223,8 +223,13 @@ skip_readlink:
 		q = l + q-p;
 	}
 
-	if (resolved) return memcpy(resolved, output, q+1);
-	else return strdup(output);
+	struct stat st = {0};
+	if (resolved) {
+		if (stat(resolved, &st) == -1) return NULL;
+		return memcpy(resolved, output, q+1);
+	}
+	if (stat(output, &st) == -1) return NULL;
+	return strdup(output);
 
 toolong:
 	errno = ENAMETOOLONG;


### PR DESCRIPTION
There was some more weirdness with realpath on WASM, causing some trouble with consulting.
As far as I can tell, the WASI implementation of `readlink` likely has different behavior than what musl expects, so an incorrect `errno` is getting set and it's confusing the consulting code.
Anyway, adding a stat at the end of it fixes everything. I've had this change running the JS/Go versions for a while and it's working well.