### PR TITLE
Fix for ASCII control characters in json(true) mode

### DIFF
--- a/src/print.c
+++ b/src/print.c
@@ -217,9 +217,9 @@ size_t formatted(char *dst, size_t dstlen, const char *src, int srclen, bool dq,
 				len += n;
 				if (dstlen) dst += n;
 
-				len += 2;
+				len++;
 			}
-		}
+			}
 		} else if (ch == '\\') {
 			if (dstlen) {
 				*dst++ = '\\';


### PR DESCRIPTION
Thanks a bunch for the JSON stuff. Found one minor issue, here's a fix.

Before this patch:
```console
?- write_term_to_chars("\x3\", [json(true)], Cs).
   Cs = "\"\\u0003".
% (cuts off the last quote)
```

After this patch:
```console
?- write_term_to_chars("\x3\", [json(true)], Cs).
   Cs = "\"\\u0003\"".
```