### PR TITLE
Fix nb_current/2

### DIFF
--- a/library/builtins.pl
+++ b/library/builtins.pl
@@ -543,7 +543,8 @@ nb_delete(K) :-
 nb_delete(_).
 
 nb_current(K, V) :-
-	user:clause('$global_key'(K, V), nb_current/2).
+	can_be(K, atom, nb_current/2, _),
+	user:clause('$global_key'(K, V), true).
 
 %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%


### PR DESCRIPTION
Small fix for `nb_current/2`.

Before:
```console
?- nb_setval(a, b).
   true.
?- nb_current(X, Y).
   false.
?- nb_current(a, Y).
   false.
?- nb_current(1, Y).
   false.
```

After fix:
```console
?- nb_setval(a, b).
   true.
?- nb_current(X, Y).
   X = a, Y = b.
?- nb_current(a, Y).
   Y = b.
?- nb_current(1, Y).
   error(type_error(atom,1),nb_current/2).
```