### PR TITLE
Fix term_to_atom/2

### DIFF
--- a/library/builtins.pl
+++ b/library/builtins.pl
@@ -452,7 +452,7 @@ chars_urlenc(Plain, Url, Opts) :- urlenc(Plain, Url, Opts).
 
 :- help(chars_urlenc(+atom,?atom,+list), [iso(false)]).
 
-term_to_atom(T, S) :- write_term_to_chars(S, T, []).
+term_to_atom(T, S) :- write_term_to_chars(T, [], S).
 
 :- help(term_to_atom(+term,?atom), [iso(false)]).
 


### PR DESCRIPTION
Small fix for `term_to_atom/2` which was using the old argument order for `write_term_to_chars/3`.

Before:
```
?- term_to_atom(abc, Y).
   error(type_error(list,abc),write_term_to_chars/3).
```

After:
```
?- term_to_atom(abc, Y).
   Y = "abc".
```