### PR TITLE
Automatic binary releases

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -34,25 +34,69 @@
         - name: Test
           run: make test
         - name: Upload artifacts
-          uses: actions/upload-artifact@v1
+          uses: actions/upload-artifact@v3
           with:
-            name: ${{ format( 'tpl-{0}', matrix.os) }}
-            path: tpl
+            name: ${{ format('tpl-{0}-{1}', runner.os, runner.arch) }}
+            path: |
+              tpl
+              LICENSE
+              ATTRIBUTION
+              README.md
+
+    windows:
+      name: Windows
+      runs-on: windows-latest
+      defaults:
+        run:
+          shell: msys2 {0}
+      steps:
+        - uses: msys2/setup-msys2@v2
+        - uses: actions/checkout@v1
+        - name: Install deps
+          run: |
+            pacman --noconfirm -S make mingw-w64-x86_64-gcc mingw-w64-x86_64-headers-git mingw-w64-x86_64-libffi mingw-w64-x86_64-dlfcn
+            pacman --noconfirm -S mingw-w64-x86_64-openssl mingw-w64-x86_64-readline vim diffutils
+        - name: Build
+          run: make ISOCLINE=1 release
+        - name: Test
+          run: make test
+        - name: Make Windows-friendly
+          run: |
+            cp ${MINGW_PREFIX}/bin/{libcrypto-3-x64.dll,libssl-3-x64.dll,libffi-8.dll} .
+            echo -e "\n\nOpenSSL (libcrypto-3-x64.dll, libssl-3-x64.dll):\n" >> ATTRIBUTION
+            cat ${MINGW_PREFIX}/share/licenses/openssl/LICENSE >> ATTRIBUTION
+            echo -e "\n\nlibffi: (libffi-8.dll)\n" >> ATTRIBUTION
+            cat ${MINGW_PREFIX}/share/licenses/libffi/LICENSE >> ATTRIBUTION
+            echo -e "\n\nisocline:\n" >> ATTRIBUTION
+            cat src/isocline/LICENSE >> ATTRIBUTION
+            mv tpl tpl.exe
+            mv ATTRIBUTION ATTRIBUTION.txt
+            mv LICENSE LICENSE.txt
+        - name: Upload artifacts
+          uses: actions/upload-artifact@v3
+          with:
+            name: ${{ format('tpl-{0}-{1}', runner.os, runner.arch) }}
+            path: |
+              tpl.exe
+              LICENSE.txt
+              ATTRIBUTION.txt
+              README.md
+              libcrypto-3-x64.dll
+              libssl-3-x64.dll
+              libffi-8.dll
 
     # Roughly matches https://github.com/WebAssembly/wasi-sdk#install
     wasm:
       name: WebAssembly
       runs-on: ubuntu-latest
       env:
-        WASI_VERSION: 12
+        WASI_VERSION: 19
         BINARYEN_VERSION: 109
-        WAPM_REGISTRY_TOKEN: ${{ secrets.WAPM_REGISTRY_TOKEN }}
       steps:
         - uses: actions/checkout@v1
         - name: Set environment (1/3)
           run: |
             echo "WASI_VERSION_FULL=${WASI_VERSION}.0" >> $GITHUB_ENV
-            echo "RELEASE_VERSION=`git tag --points-at HEAD | sed 's/^v//'`" >> $GITHUB_ENV
         - name: Set environment (2/3)
           run: |
             echo "WASI_SDK_PATH=`pwd`/wasi-sdk-${WASI_VERSION_FULL}" >> $GITHUB_ENV
@@ -66,26 +110,53 @@
             wget https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-${WASI_VERSION}/wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
             tar xvf wasi-sdk-${WASI_VERSION_FULL}-linux.tar.gz
         - name: Install Binaryen
-          run: brew install binaryen
-        - name: Setup Wasmer
+          run: |
+            brew install binaryen
+        - name: Install Wasmer
           uses: wasmerio/setup-wasmer@v1
         - name: Build
-          run: |
-            make clean
-            make wasm
+          run: make clean wasm
         - name: Test
           run: |
             echo 'wasmer --dir . tpl.wasm -- $@' > tpl
             chmod +x tpl
             make test
         - name: Upload artifacts
-          uses: actions/upload-artifact@v1
+          uses: actions/upload-artifact@v3
           with:
-            name: tpl.wasm
-            path: tpl.wasm
-        - name: Publish on WAPM
+            name: tpl-wasm-wasi
+            path: |
+              tpl.wasm
+              LICENSE
+              ATTRIBUTION
+              README.md
+
+    release:
+      if: startsWith(github.ref, 'refs/tags/')
+      needs: [build, windows, wasm]
+      name: Release binaries
+      runs-on: ubuntu-latest
+      steps:
+        - name: Download artifacts
+          uses: actions/download-artifact@v3
+          with:
+            path: artifacts
+        - name: List files
+          run: ls -R
+        - name: Zip releases
           run: |
-            sed -i "s/__RELEASE_VERSION__/$RELEASE_VERSION/" wapm.toml
-            wapm login $WAPM_REGISTRY_TOKEN
-            wapm publish
-          if: ${{ env.WAPM_REGISTRY_TOKEN != '' && env.RELEASE_VERSION != '' }}
+            cd artifacts
+            chmod +x */tpl* */*.wasm
+            for i in */; do
+              dir=${i%/}
+              lower=${dir,,}
+              if [ "$dir" != "$lower" ]
+              then
+                mv "$dir" "$lower"
+              fi
+              zip -r "${lower}.zip" "$lower"
+            done
+        - name: Publish
+          uses: softprops/action-gh-release@v1
+          with:
+            files: 'artifacts/*.zip'

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,13 @@ CFLAGS =  -std=gnu99 -Isrc -I/usr/local/include -DVERSION='$(GIT_VERSION)' -O3 \
 LDFLAGS = -L/usr/local/lib -lm
 
 ifdef WASI
-CFLAGS += -D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL -Isrc/wasm -O0 -std=c11
-LDFLAGS += -o tpl.wasm -lwasi-emulated-mman -lwasi-emulated-signal -Wl,--stack-first -Wl,-zstack-size=8388608 -Wl,--initial-memory=100663296
+CFLAGS += -std=c11 -Isrc/wasm \
+	-D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL \
+	-D_WASI_EMULATED_PROCESS_CLOCKS
+LDFLAGS += -lwasi-emulated-mman -lwasi-emulated-signal \
+	-lwasi-emulated-process-clocks -Wl,--stack-first \
+	-Wl,-zstack-size=8388608 -Wl,--initial-memory=100663296 \
+	-o tpl.wasm
 NOFFI = 1
 NOSSL = 1
 ifdef WASI_CC
@@ -45,6 +50,10 @@ endif
 ifdef LTO
 CFLAGS += -flto=$(LTO)
 LDFLAGS += -flto=$(LTO)
+endif
+
+ifndef WASMOPT
+WASMOPT = wasm-opt
 endif
 
 SRCOBJECTS = tpl.o \
@@ -130,10 +139,11 @@ release:
 	$(MAKE) 'OPT=$(OPT) -DNDEBUG'
 
 tpl.wasm:
-	$(MAKE) WASI=1 'OPT=$(OPT) -O0 -DNDEBUG'
+	$(MAKE) WASI=1 'OPT=$(OPT) -DNDEBUG'
 
 wasm: tpl.wasm
-	wasm-opt tpl.wasm -o tpl.wasm -O4
+	$(WASMOPT) --enable-bulk-memory tpl.wasm -o tpl-opt.wasm -O4
+	mv tpl-opt.wasm tpl.wasm
 
 test:
 	./tests/run.sh

--- a/src/query.c
+++ b/src/query.c
@@ -1888,7 +1888,11 @@ static int my_clock_gettime(clockid_t type, struct timespec *tp)
 uint64_t cpu_time_in_usec(void)
 {
 	struct timespec now = {0};
+#ifdef CLOCK_PROCESS_CPUTIME_ID
 	my_clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &now);
+#else
+	my_clock_gettime(CLOCK_MONOTONIC, &now);
+#endif
 	return (uint64_t)(now.tv_sec * 1000 * 1000) + (now.tv_nsec / 1000);
 }
 


### PR DESCRIPTION
This updates the GitHub action workflow to automatically release binaries when a tag is created.
You can see an example of a release here: https://github.com/guregu/trealla/releases/tag/v0.0.0-test123 (cut from 104b6cc + this PR)

Includes support for Linux (Ubuntu x64), macOS (x64 for now, I'll add M1 support when GitHub adds runners for it), Windows, and WASM (WASI).
Each release includes tpl (from `make release`), LICENSE, ATTRIBUTION, and README.md.
The Windows release uses isocline and also includes the mingw DLLs for OpenSSL and libffi. It appends their licenses to ATTRIBUTION. Neither of these have infectious licenses so it should be fine to bundle them. Including them allows it to run out of the box on Windows with crypto support. The non-Windows releases don't bundle any dependencies.

To get it to work, make sure that in repository [Settings → Actions → General](https://github.com/trealla-prolog/trealla/settings/actions), under Workflow permissions at the bottom, "Read and write" permissions are enabled. The workflow needs these to cut the GitHub release.
To release a new version you don't have to do anything differently. Pushing a tag for a new version will automatically make everything happen.

This PR also updates the WASM build toolchain to the latest versions, and enables compiler optimizations (which makes it a lot faster -- it's down to about 2x slower than native). I removed the WAPM stuff as well.
If it breaks I promise to fix it :-)