### PR TITLE
Yield tweaks for Wasm port

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,11 @@ CFLAGS =  -std=gnu99 -Isrc -I/usr/local/include -DVERSION='$(GIT_VERSION)' -O3 \
 
 LDFLAGS = -L/usr/local/lib -lm
 
+ifdef HOMEBREW_PREFIX
+LDFLAGS += -L$(HOMEBREW_PREFIX)/opt/libffi/lib -L$(HOMEBREW_PREFIX)/opt/openssl@3/lib
+CFLAGS += -I$(HOMEBREW_PREFIX)/opt/libffi/include -I$(HOMEBREW_PREFIX)/opt/openssl@3/include
+endif
+
 ifdef WASI
 CFLAGS += -std=c11 -Isrc/wasm \
 	-D_WASI_EMULATED_MMAN -D_WASI_EMULATED_SIGNAL \

--- a/src/internal.h
+++ b/src/internal.h
@@ -71,6 +71,8 @@ extern unsigned g_string_cnt, g_interned_cnt;
 
 #define STREAM_BUFLEN 1024
 
+#define YIELD_INTERVAL 10000	// Goal interval between yield checks
+
 #define MAX_OF(a,b) (a) > (b) ? (a) : (b)
 #define MIN_OF(a,b) (a) < (b) ? (a) : (b)
 

--- a/src/module.c
+++ b/src/module.c
@@ -1613,7 +1613,7 @@ module *load_text(module *m, const char *src, const char *filename)
 			SB(src);
 			SB_sprintf(src, "forall(%s:retract((:- initialization(__G_))), (__G_ -> true ; format('Warning: call(~w) failed~n', [__G_])))", p->m->name);
 
-			if (run(p, SB_cstr(src), false))
+			if (run(p, SB_cstr(src), false, NULL, 0))
 				p->m->pl->status = false;
 
 			SB_free(src);
@@ -1748,7 +1748,7 @@ module *load_fp(module *m, FILE *fp, const char *filename, bool including)
 			SB(src);
 			SB_sprintf(src, "forall(%s:retract((:- initialization(__G_))), (__G_ -> true ; format('Warning: call(~w) failed~n', [__G_])))", p->m->name);
 
-			if (run(p, SB_cstr(src), false))
+			if (run(p, SB_cstr(src), false, NULL, 0))
 				p->m->pl->status = false;
 
 			SB_free(src);

--- a/src/parser.c
+++ b/src/parser.c
@@ -3478,7 +3478,7 @@ unsigned tokenize(parser *p, bool args, bool consing)
 	return !p->error;
 }
 
-bool run(parser *p, const char *pSrc, bool dump)
+bool run(parser *p, const char *pSrc, bool dump, query **subq, unsigned int yield_time_in_ms)
 {
 	if ((*pSrc == '.') && !pSrc[1]) {
 		fprintf(stdout, "Error: syntax error, unexpected end of rule, %s:%d\n", get_loaded(p->m, p->m->filename), p->line_nbr);
@@ -3529,6 +3529,12 @@ bool run(parser *p, const char *pSrc, bool dump)
 			SB_free(src);
 			return false;
 		}
+
+		if (subq)
+			*subq = q;
+
+		if (yield_time_in_ms > 0)
+			do_yield_at(q, yield_time_in_ms);
 
 		p->pl->curr_query = q;
 		q->p = p;

--- a/src/parser.h
+++ b/src/parser.h
@@ -11,7 +11,7 @@ unsigned tokenize(parser *p, bool args, bool consing);
 void reset(parser *p);
 void term_to_body(parser *p);
 cell *check_body_callable(parser *p, cell *c);
-bool run(parser *p, const char *src, bool dump);
+bool run(parser *p, const char *src, bool dump, query **subq, unsigned int yield_time_in_ms);
 char *eat_space(parser *p);
 bool virtual_term(parser *p, const char *src);
 bool get_token(parser *p, bool last_op, bool was_postfix);

--- a/src/predicates.c
+++ b/src/predicates.c
@@ -59,6 +59,12 @@ bool do_yield(query *q, int msecs)
 	return false;
 }
 
+void do_yield_at(query *q, unsigned int time_in_ms)
+{
+	q->yield_at = get_time_in_usec() / 1000;
+	q->yield_at += time_in_ms > 0 ? time_in_ms : 1;
+}
+
 static void make_ref(cell *tmp, pl_idx_t off, unsigned var_nbr, pl_idx_t ctx)
 {
 	*tmp = (cell){0};

--- a/src/prolog.c
+++ b/src/prolog.c
@@ -124,14 +124,14 @@ bool pl_eval(prolog *pl, const char *s)
 	pl->p = create_parser(pl->curr_m);
 	if (!pl->p) return false;
 	pl->p->command = true;
-	bool ok = run(pl->p, s, true);
+	bool ok = run(pl->p, s, true, NULL, 0);
 	if (get_status(pl)) pl->curr_m = pl->p->m;
 	destroy_parser(pl->p);
 	pl->p = NULL;
 	return ok;
 }
 
-bool pl_query(prolog *pl, const char *s, pl_sub_query **subq)
+bool pl_query(prolog *pl, const char *s, pl_sub_query **subq, unsigned int yield_time_in_ms)
 {
 	if (!pl || !*s || !subq)
 		return false;
@@ -140,8 +140,7 @@ bool pl_query(prolog *pl, const char *s, pl_sub_query **subq)
 	if (!pl->p) return false;
 	pl->p->command = true;
 	pl->is_query = true;
-	bool ok = run(pl->p, s, true);
-	*subq = (pl_sub_query*)pl->curr_query;
+	bool ok = run(pl->p, s, true, (query**)subq, yield_time_in_ms);
 	if (get_status(pl)) pl->curr_m = pl->p->m;
 	return ok;
 }
@@ -160,14 +159,13 @@ bool pl_redo(pl_sub_query *subq)
 	return false;
 }
 
-bool pl_yield_at(pl_sub_query *subq, uint64_t time_in_ms)
+bool pl_yield_at(pl_sub_query *subq, unsigned int time_in_ms)
 {
 	if (!subq)
 		return false;
 
 	query *q = (query*)subq;
-	q->yield_at = get_time_in_usec() / 1000;
-	q->yield_at += time_in_ms > 0 ? time_in_ms : 1;
+	do_yield_at(q, time_in_ms);
 	return true;
 }
 
@@ -177,8 +175,7 @@ bool pl_did_yield(pl_sub_query *subq)
 		return false;
 
 	query *q = (query*)subq;
-	uint64_t now = get_time_in_usec() / 1000;
-	return now > q->yield_at;
+	return q->yielded;
 }
 
 bool pl_done(pl_sub_query *subq)

--- a/src/query.c
+++ b/src/query.c
@@ -1712,16 +1712,6 @@ bool start(query *q)
 		if (q->retry) {
 			Trace(q, q->st.curr_cell, q->st.curr_frame, FAIL);
 
-			if (q->yield_at) {
-				uint64_t now = get_time_in_usec() / 1000;
-
-				if (now > q->yield_at)  {
-					q->yield_at = 0;
-					do_yield(q, 0);
-					break;
-				}
-			}
-
 			if (!retry_choice(q))
 				break;
 		}
@@ -1760,6 +1750,16 @@ bool start(query *q)
 			if (q->retry == QUERY_SKIP) {
 				q->retry = QUERY_OK;
 				continue;
+			}
+
+			if (q->yield_at && q->tot_goals % YIELD_INTERVAL == 0) {
+				uint64_t now = get_time_in_usec() / 1000;
+
+				if (now > q->yield_at)  {
+					q->yield_at = 0;
+					do_yield(q, 0);
+					break;
+				}
 			}
 
 			if (!status && !q->is_oom) {

--- a/src/query.h
+++ b/src/query.h
@@ -14,6 +14,7 @@ bool push_catcher(query *q, enum q_retry type);
 bool do_retract(query *q, cell *p1, pl_idx_t p1_ctx, enum clause_type is_retract);
 bool do_read_term(query *q, stream *str, cell *p1, pl_idx_t p1_ctx, cell *p2, pl_idx_t p2_ctx, char *src);
 bool do_yield(query *q, int msecs);
+void do_yield_at(query *q, unsigned int time_in_ms);
 
 bool query_redo(query *q);
 bool has_next_key(query *q);

--- a/src/trealla.h
+++ b/src/trealla.h
@@ -15,8 +15,8 @@ extern bool pl_eval(prolog*, const char *expr);
 extern bool pl_isatty(prolog*);
 extern FILE *pl_stdin(prolog*);
 
-extern bool pl_query(prolog*, const char *expr, pl_sub_query **q);
-extern bool pl_yield_at(pl_sub_query *q, uint64_t time_in_ms);
+extern bool pl_query(prolog*, const char *expr, pl_sub_query **q, unsigned int yield_time_in_ms);
+extern bool pl_yield_at(pl_sub_query *q, unsigned int time_in_ms);
 extern bool pl_did_yield(pl_sub_query *q);
 extern bool pl_redo(pl_sub_query *q);
 extern bool pl_done(pl_sub_query *q);	// only call if redo still active


### PR DESCRIPTION
Minor changes to some stuff to help the Wasm port, mostly related to #134:

- Moved `yield_at` check to after each goal is evaluated
  - This lets it yield before it starts retrying
- Change yield time argument to `unsigned int`
  - wasm doesn't like it when exported function arguments are wider than its native int (32 bits)
- Add yield time argument to `pl_query`
  - wasm ports need to be able to give it a time before it starts redoing, so the initial eval can yield too
- Eagerly set subquery pointer in `pl_query`
  - The Go port lets you write native predicates that can run other queries, so setting the subquery based on `pl->query` after `run` is called could point to the wrong one. Setting it earlier avoids this (had to tack it on to `run`).
- Change `pl_did_yield` to always return true if yielded (disregarding time)
  - trealla-js uses yields for awaiting HTTP fetches and stuff too, so we need a simple check against `q->yielded` here
- Add homebrew includes to Makefile if its env vars are set
  - Makes building on macOS 'just work'

Decided to use the same value as SWI's default for the yield interval (every 10,000 goals). Seems to work nicely, low overhead and feels smoother than every 1 or 10 goals. We could make this configurable later if we want (SWI uses a prolog flag called 'heartbeat').

Just for fun, some benchmarks from trealla-js + chrome:
```
% time(fib(29, _)) [no auto-yield]
% Time elapsed 0.572000s

% time(fib(29, _)) [auto-yield every 20ms / check every 10,000 goals]
% Time elapsed 0.683000s

% time(fib_hell(29, _)) [auto-yield + manual yielding]
% Time elapsed 1.883000s
```

So it's about a 20% overhead in exchange for total UI smoothness. Worth it, IMO. You can also disable it by setting some options in trealla-js (I'll make a release later today).