### PR TITLE
Fix leak in pl_query APIs

### DIFF
--- a/src/prolog.c
+++ b/src/prolog.c
@@ -141,7 +141,11 @@ bool pl_query(prolog *pl, const char *s, pl_sub_query **subq, unsigned int yield
 	pl->p->command = true;
 	pl->is_query = true;
 	bool ok = run(pl->p, s, true, (query**)subq, yield_time_in_ms);
-	if (get_status(pl)) pl->curr_m = pl->p->m;
+	if (get_status(pl))
+		pl->curr_m = pl->p->m;
+	if (!ok)
+		parser_destroy(pl->p);
+
 	return ok;
 }
 
@@ -155,6 +159,7 @@ bool pl_redo(pl_sub_query *subq)
 	if (query_redo(q))
 		return true;
 
+	parser_destroy(q->p);
 	query_destroy(q);
 	return false;
 }
@@ -184,6 +189,7 @@ bool pl_done(pl_sub_query *subq)
 		return false;
 
 	query *q = (query*)subq;
+	parser_destroy(q->p);
 	query_destroy(q);
 	return true;
 }


### PR DESCRIPTION
This only affects `pl_query`, `pl_redo` etc. and not normal usage.

Testing with the `#if 0` for `pl_query` flipped in `tpl.c`:

Before
```console
$ valgrind --leak-check=full ./tpl -g 'true ; true ; true'                                 
==31638== Memcheck, a memory error detector
==31638== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==31638== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==31638== Command: ./tpl -g true\ ;\ true\ ;\ true
==31638== 
   true
;  true
; Trealla Prolog (c) Infradig 2020-2023, b8af4-dirty
?- halt.
==31638== 
==31638== HEAP SUMMARY:
==31638==     in use at exit: 233,531 bytes in 206 blocks
==31638==   total heap usage: 21,629 allocs, 21,423 frees, 296,824,851 bytes allocated
==31638== 
==31638== 55,346 (31,048 direct, 24,298 indirect) bytes in 1 blocks are definitely lost in loss record 42 of 42
==31638==    at 0x4879F34: calloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==31638==    by 0x166073: parser_create (parser.c:174)
==31638==    by 0x1D9D9B: pl_query (prolog.c:139)
==31638==    by 0x11699F: main (tpl.c:355)
==31638== 
==31638== LEAK SUMMARY:
==31638==    definitely lost: 31,048 bytes in 1 blocks
==31638==    indirectly lost: 24,298 bytes in 2 blocks
==31638==      possibly lost: 0 bytes in 0 blocks
==31638==    still reachable: 178,185 bytes in 203 blocks
==31638==         suppressed: 0 bytes in 0 blocks
==31638== Reachable blocks (those to which a pointer was found) are not shown.
==31638== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==31638== 
==31638== For lists of detected and suppressed errors, rerun with: -s
==31638== ERROR SUMMARY: 1 errors from 1 contexts (suppressed: 0 from 0)
```

After:
```console
$ valgrind --leak-check=full ./tpl -g 'true ; true ; true'                                 
==31845== Memcheck, a memory error detector
==31845== Copyright (C) 2002-2017, and GNU GPL'd, by Julian Seward et al.
==31845== Using Valgrind-3.18.1 and LibVEX; rerun with -h for copyright info
==31845== Command: ./tpl -g true\ ;\ true\ ;\ true
==31845== 
   true
;  true
; Trealla Prolog (c) Infradig 2020-2023, 7c1d-dirty
?- halt.
==31845== 
==31845== HEAP SUMMARY:
==31845==     in use at exit: 178,185 bytes in 203 blocks
==31845==   total heap usage: 21,629 allocs, 21,426 frees, 296,824,851 bytes allocated
==31845== 
==31845== LEAK SUMMARY:
==31845==    definitely lost: 0 bytes in 0 blocks
==31845==    indirectly lost: 0 bytes in 0 blocks
==31845==      possibly lost: 0 bytes in 0 blocks
==31845==    still reachable: 178,185 bytes in 203 blocks
==31845==         suppressed: 0 bytes in 0 blocks
==31845== Reachable blocks (those to which a pointer was found) are not shown.
==31845== To see them, rerun with: --leak-check=full --show-leak-kinds=all
==31845== 
==31845== For lists of detected and suppressed errors, rerun with: -s
==31845== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)
```