### PR TITLE
Fix Windows build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -69,7 +69,9 @@
             cat ${MINGW_PREFIX}/share/licenses/libffi/LICENSE >> ATTRIBUTION
             echo -e "\n\nisocline:\n" >> ATTRIBUTION
             cat src/isocline/LICENSE >> ATTRIBUTION
-            mv tpl tpl.exe
+            if [ ! -f "tpl.exe" ]; then
+              mv tpl tpl.exe
+            fi
             mv ATTRIBUTION ATTRIBUTION.txt
             mv LICENSE LICENSE.txt
         - name: Upload artifacts


### PR DESCRIPTION
(hopefully)

Might need a few tries to fix, sorry if it spams your email.
Maybe GitHub actions mingw builds with .exe by default now?