### PR TITLE
Fix typo in Windows release ATTRIBUTION

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@
             cat ${MINGW_PREFIX}/share/licenses/openssl/LICENSE >> ATTRIBUTION
             echo -e "\n\nlibffi: (libffi-8.dll)\n" >> ATTRIBUTION
             cat ${MINGW_PREFIX}/share/licenses/libffi/LICENSE >> ATTRIBUTION
-            echo -e "\n\dlfcn: (libdl.dll)\n" >> ATTRIBUTION
+            echo -e "\n\ndlfcn: (libdl.dll)\n" >> ATTRIBUTION
             cat ${MINGW_PREFIX}/share/licenses/dlfcn/LICENSE >> ATTRIBUTION
             echo -e "\n\nisocline:\n" >> ATTRIBUTION
             cat src/isocline/LICENSE >> ATTRIBUTION


### PR DESCRIPTION
Minor typo in Windows build attribution. Missed a spot in my last patch 🙈 
