### PR TITLE
Switch wasm CI tests to Wasmtime

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -131,13 +131,15 @@
         - name: Install Binaryen
           run: |
             brew install binaryen
-        - name: Install Wasmer
-          uses: wasmerio/setup-wasmer@v1
+        - name: Setup Wasmtime
+          uses: mwilliamson/setup-wasmtime-action@v2
+          with:
+            wasmtime-version: "12.0.1"
         - name: Build
           run: make clean wasm
         - name: Test
           run: |
-            echo 'wasmer --dir . tpl.wasm -- $@' > tpl
+            echo 'wasmtime run --max-wasm-stack 8388608 --dir . tpl.wasm -- $@' > tpl
             chmod +x tpl
             make test
         - name: Upload artifacts


### PR DESCRIPTION
Fixes #307. I think the previous action is running an outdated version of Node or something, or maybe GitHub is just struggling 🤷.