### PR TITLE
Fix leak in term printing

### DIFF
--- a/src/stringbuf.h
+++ b/src/stringbuf.h
@@ -79,9 +79,10 @@ typedef struct {
 }
 
 #define SB_strcpy_and_free(pr,s) {								\
-	if (s) {													\
-		SB_strcpy(pr, s);										\
-		free(s);												\
+	char *s2 = (s);												\
+	if (s2) {													\
+		SB_strcpy(pr, s2);										\
+		free(s2);												\
 	}															\
 }
 
@@ -95,9 +96,10 @@ typedef struct {
 }
 
 #define SB_strcat_and_free(pr,s) {								\
-	if (s) {													\
-		SB_strcat(pr, s);										\
-		free(s);												\
+	char *s2 = (s);												\
+	if (s2) {													\
+		SB_strcat(pr, s2);										\
+		free(s2);												\
 	}															\
 }
 


### PR DESCRIPTION
`print.c` has a few instances of code like:

```c
SB_strcat_and_free(q->sb, formatted(C_STR(q, h), C_STRLEN(q, h), false, false));
```

The macro would expand to calling `formatted` twice and only free one of them. This is a quick fix for it.

You can verify it with this (it's triggered just by loading the default modules):
```console
valgrind --leak-check=full ./tpl -g halt
```