### PR TITLE
Support clause/2,3 for non-dynamic clauses

### DIFF
--- a/src/parser.c
+++ b/src/parser.c
@@ -957,6 +957,11 @@ static bool directives(parser *p, cell *d)
 				p->m->flags.occurs_check = true;
 			else if (!strcmp(C_STR(p, p2), "false") || !strcmp(C_STR(p, p2), "off"))
 				p->m->flags.occurs_check = false;
+		} else if (!strcmp(C_STR(p, p1), "strict_iso")) {
+			if (!strcmp(C_STR(p, p2), "true") || !strcmp(C_STR(p, p2), "on"))
+				p->m->flags.not_strict_iso = false;
+			else if (!strcmp(C_STR(p, p2), "false") || !strcmp(C_STR(p, p2), "off"))
+				p->m->flags.not_strict_iso = true;
 		} else {
 			//fprintf(stdout, "Warning: unknown flag: %s\n", C_STR(p, p1));
 		}

--- a/src/query.c
+++ b/src/query.c
@@ -1282,9 +1282,10 @@ bool match_clause(query *q, cell *p1, pl_idx p1_ctx, enum clause_type is_retract
 		}
 
 		if (!pr->is_dynamic) {
-			if (is_retract == DO_CLAUSE)
-				return throw_error(q, p1, p1_ctx, "permission_error", "access,private_procedure");
-			else
+			if (is_retract == DO_CLAUSE) {
+				if (!q->flags.not_strict_iso)
+					return throw_error(q, p1, p1_ctx, "permission_error", "access,private_procedure");
+			} else
 				return throw_error(q, p1, p1_ctx, "permission_error", "modify,static_procedure");
 		}
 

--- a/tests/issues/test372.expected
+++ b/tests/issues/test372.expected
@@ -1,0 +1,2 @@
+answer(41):-1=:=2,fail
+answer(42):-true

--- a/tests/issues/test372.pl
+++ b/tests/issues/test372.pl
@@ -1,0 +1,8 @@
+:-initialization(main).
+:-set_prolog_flag(strict_iso,off).
+
+answer(41) :- 1 =:= 2, fail.
+answer(42).
+
+main :- H = answer(X), clause(H, Body), writeln((H :- Body)), fail.
+main.


### PR DESCRIPTION
Re: #372. Loosens restriction when strict_iso is off, and adds support for the set_prolog_flag directive.