### PR TITLE
Support public/1 directive, add public_clauses flag (#372)

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -460,6 +460,7 @@ struct predicate_ {
 	bool is_reload:1;
 	bool is_prebuilt:1;
 	bool is_public:1;
+	bool is_exported:1;
 	bool is_dynamic:1;
 	bool is_meta_predicate:1;
 	bool is_multifile:1;
@@ -631,6 +632,7 @@ struct prolog_flags_ {
 	bool debug:1;
 	bool json:1;
 	bool var_prefix:1;
+	bool public_clauses:1;
 };
 
 struct query_ {

--- a/src/module.c
+++ b/src/module.c
@@ -650,6 +650,23 @@ void set_dynamic_in_db(module *m, const char *name, unsigned arity)
 		m->error = true;
 }
 
+void set_public_in_db(module *m, const char *name, unsigned arity)
+{
+	cell tmp = (cell){0};
+	tmp.tag = TAG_INTERNED;
+	tmp.val_off = new_atom(m->pl, name);
+	ensure(tmp.val_off != ERR_IDX);
+	tmp.arity = arity;
+	predicate *pr = find_predicate(m, &tmp);
+	if (!pr) pr = create_predicate(m, &tmp, NULL);
+
+	if (pr) {
+		push_property(m, name, arity, "public");
+		pr->is_public = true;
+	} else
+		m->error = true;
+}
+
 void set_meta_predicate_in_db(module *m, cell *c)
 {
 	const char *name = C_STR(m, c);

--- a/src/module.h
+++ b/src/module.h
@@ -54,5 +54,6 @@ db_entry *erase_from_db(module *m, uuid *ref);
 void set_meta_predicate_in_db(module *m, cell *c);
 void set_discontiguous_in_db(module *m, const char *name, unsigned arity);
 void set_dynamic_in_db(module *m, const char *name, unsigned arity);
+void set_public_in_db(module *m, const char *name, unsigned arity);
 void set_multifile_in_db(module *m, const char *name, pl_idx arity);
 void set_det_in_db(module *m, const char *name, pl_idx arity);

--- a/src/parser.c
+++ b/src/parser.c
@@ -877,7 +877,8 @@ static bool directives(parser *p, cell *d)
 					push_property(p->m, C_STR(p, &tmp), tmp.arity, "static");
 					push_property(p->m, C_STR(p, &tmp), tmp.arity, "visible");
 					push_property(p->m, C_STR(p, &tmp), tmp.arity, "interpreted");
-					pr->is_public = true;
+					push_property(p->m, C_STR(p, &tmp), tmp.arity, "exported");
+					pr->is_exported = true;
 				} else if (!strcmp(C_STR(p, head), "op") && (head->arity == 3)) {
 					do_op(p, head, true);
 				}
@@ -957,11 +958,16 @@ static bool directives(parser *p, cell *d)
 				p->m->flags.occurs_check = true;
 			else if (!strcmp(C_STR(p, p2), "false") || !strcmp(C_STR(p, p2), "off"))
 				p->m->flags.occurs_check = false;
+		} else if (!strcmp(C_STR(p, p1), "public_clauses")) {
+			if (!strcmp(C_STR(p, p2), "true") || !strcmp(C_STR(p, p2), "on"))
+				p->m->flags.public_clauses = true;
+			else if (!strcmp(C_STR(p, p2), "false") || !strcmp(C_STR(p, p2), "off"))
+				p->m->flags.public_clauses = false;
 		} else if (!strcmp(C_STR(p, p1), "strict_iso")) {
 			if (!strcmp(C_STR(p, p2), "true") || !strcmp(C_STR(p, p2), "on"))
-				p->m->flags.not_strict_iso = false;
+				p->m->flags.not_strict_iso = !true;
 			else if (!strcmp(C_STR(p, p2), "false") || !strcmp(C_STR(p, p2), "off"))
-				p->m->flags.not_strict_iso = true;
+				p->m->flags.not_strict_iso = !false;
 		} else {
 			//fprintf(stdout, "Warning: unknown flag: %s\n", C_STR(p, p1));
 		}
@@ -1021,6 +1027,7 @@ static bool directives(parser *p, cell *d)
 				set_dynamic_in_db(p->m, C_STR(p, c_name), arity);
 			} else if (!strcmp(dirname, "encoding")) {
 			} else if (!strcmp(dirname, "public")) {
+				set_public_in_db(p->m, C_STR(p, c_name), arity);
 			} else if (!strcmp(dirname, "export")) {
 			} else if (!strcmp(dirname, "discontiguous")) {
 				set_discontiguous_in_db(p->m, C_STR(p, c_name), arity);
@@ -1115,7 +1122,7 @@ static bool directives(parser *p, cell *d)
 			else if (!strcmp(dirname, "discontiguous"))
 				set_discontiguous_in_db(m, C_STR(p, c_name), arity);
 			else if (!strcmp(dirname, "public"))
-				;
+				set_public_in_db(m, C_STR(p, c_name), arity);
 			else if (!strcmp(dirname, "export"))
 				;
 			else if (!strcmp(dirname, "dynamic")) {

--- a/src/query.c
+++ b/src/query.c
@@ -1283,7 +1283,7 @@ bool match_clause(query *q, cell *p1, pl_idx p1_ctx, enum clause_type is_retract
 
 		if (!pr->is_dynamic) {
 			if (is_retract == DO_CLAUSE) {
-				if (!q->flags.not_strict_iso)
+				if (!pr->is_public && !q->flags.public_clauses)
 					return throw_error(q, p1, p1_ctx, "permission_error", "access,private_procedure");
 			} else
 				return throw_error(q, p1, p1_ctx, "permission_error", "modify,static_procedure");

--- a/tests/issues/test372.expected
+++ b/tests/issues/test372.expected
@@ -1,2 +1,3 @@
-answer(41):-1=:=2,fail
-answer(42):-true
+answer(41):-abc,fail.
+answer(42):-true.
+on

--- a/tests/issues/test372.pl
+++ b/tests/issues/test372.pl
@@ -1,8 +1,9 @@
 :-initialization(main).
-:-set_prolog_flag(strict_iso,off).
+:-set_prolog_flag(public_clauses,on).
 
-answer(41) :- 1 =:= 2, fail.
+answer(41) :- abc, fail.
 answer(42).
 
-main :- H = answer(X), clause(H, Body), writeln((H :- Body)), fail.
+main :- H = answer(_), clause(H, Body), write_term((H :- Body), [nl(true), fullstop(true)]), fail.
+main :- current_prolog_flag(public_clauses, Flag), writeln(Flag), fail.
 main.

--- a/tests/tests/test095.expected
+++ b/tests/tests/test095.expected
@@ -1,0 +1,4 @@
+answer(41):-abc,fail.
+answer(42):-true.
+ok
+error(permission_error(access,private_procedure,not_public/1),clause/2)

--- a/tests/tests/test095.pl
+++ b/tests/tests/test095.pl
@@ -1,0 +1,12 @@
+:-initialization(main).
+:-public(answer/1).
+
+answer(41) :- abc, fail.
+answer(42).
+
+not_public(_).
+
+main :- H = answer(_), clause(H, Body), write_term((H :- Body), [nl(true), fullstop(true)]), fail.
+main :- predicate_property(answer(_), (public)), writeln(ok), fail.
+main :- catch(clause(not_public(_), _), Error, writeln(Error)), fail.
+main.


### PR DESCRIPTION
See: #372. Applied feedback from @UWN.

Changes:
- Support `public/1` directive
- Add `public_clauses` flag that bypasses the public-private check when `on` (`off` by default)
  - Feel free to name this something else
- Add `predicate_property/2` for publicness 
- Undo `strict_iso` stuff for clause/2 that was added in #373

Internal stuff:
- Added is_exported bit for predicates
- Use is_exported instead of is_public for module exporting stuff
- Remove a singleton var from the tests I added 🙈 
- Add a test for `public/1` directive
- I left `module.make_public` alone as I wasn't sure exactly what it was for.