### PR TITLE
Fix xxd build error for certain versions of vim

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,8 @@ endif
 OBJECTS = $(SRCOBJECTS) $(LIBOBJECTS) src/version.o
 
 library/%.c: library/%.pl
-	xxd -i $^ $@
+	echo '#include <stddef.h>' > $@
+	xxd -i $^ >> $@
 
 all: tpl
 


### PR DESCRIPTION
https://github.com/vim/vim/issues/13876 changed xxd to use `size_t` instead of `unsigned int` which randomly(?) [breaks the build](https://github.com/trealla-prolog/trealla/actions/runs/7711249038/job/21016239767).

I'm not sure why this only happens occasionally, perhaps something to do with Github Actions caching. The change has already been reverted in Vim so it should only happen in a very specific version. Feel free to close this if it doesn't happen again.