### PR TITLE
Fix uninitialized pointer in loaded_file 

### DIFF
--- a/src/module.c
+++ b/src/module.c
@@ -136,6 +136,7 @@ static const char *set_known(module *m, const char *filename)
 	ptr->orig_filename = strdup(filename);
 	ptr->filename = strdup(filename);
 	ptr->is_loaded = false;
+	ptr->parent = NULL;
 	m->loaded_files = ptr;
 	return ptr->filename;
 }
@@ -161,6 +162,7 @@ static const char *set_loaded(module *m, const char *filename, const char *orig_
 	ptr->filename = strdup(filename);
 	ptr->when_loaded = time(0);
 	ptr->is_loaded = true;
+	ptr->parent = NULL;
 	m->loaded_files = ptr;
 	//printf("*** set_loaded '%s'\n", filename);
 	return ptr->filename;


### PR DESCRIPTION
To see why this causes an issue, try running `valgrind --leak-check=full --track-origins=yes ./tpl`, `consult(something)`, edit that file and then `make`. If the stars are (not) aligned:

```
==16695== Conditional jump or move depends on uninitialised value(s)
==16695==    at 0x236694: get_parent (module.c:218)
==16695==    by 0x236887: make (module.c:264)
==16695==    by 0x20B047: bif_make_0 (bif_streams.c:4907)
==16695==    by 0x283C2F: start (query.c:1643)
==16695==    by 0x2846F7: execute (query.c:1855)
==16695==    by 0x259917: run (parser.c:4055)
==16695==    by 0x277C87: pl_eval (prolog.c:144)
==16695==    by 0x118753: main (tpl.c:375)
==16695==  Uninitialised value was created by a heap allocation
==16695==    at 0x48850E8: malloc (in /usr/libexec/valgrind/vgpreload_memcheck-arm64-linux.so)
==16695==    by 0x23642B: set_loaded (module.c:157)
==16695==    by 0x23F24B: load_file (module.c:2108)
==16695==    by 0x209A6F: do_consult (bif_streams.c:4783)
==16695==    by 0x20AA53: bif_load_files_2 (bif_streams.c:4860)
==16695==    by 0x283C2F: start (query.c:1643)
==16695==    by 0x2846F7: execute (query.c:1855)
==16695==    by 0x259917: run (parser.c:4055)
==16695==    by 0x277C87: pl_eval (prolog.c:144)
==16695==    by 0x118753: main (tpl.c:375)
```

Can lead to crashes, but luckily it's a quick fix.