### PR TITLE
pl_yield_at fixes

### DIFF
--- a/src/bif_streams.c
+++ b/src/bif_streams.c
@@ -1902,9 +1902,6 @@ static bool bif_iso_flush_output_1(query *q)
 
 static bool bif_iso_nl_0(query *q)
 {
-	if (q->retry)
-		return true;
-
 	int n = q->pl->current_output;
 	stream *str = &q->pl->streams[n];
 	fputc('\n', str->fp);
@@ -1918,9 +1915,6 @@ static bool bif_iso_nl_0(query *q)
 
 static bool bif_iso_nl_1(query *q)
 {
-	if (q->retry)
-		return true;
-
 	GET_FIRST_ARG(pstr,stream);
 	int n = get_stream(q, pstr);
 	stream *str = &q->pl->streams[n];

--- a/src/builtins.h
+++ b/src/builtins.h
@@ -78,6 +78,7 @@ bool bif_iso_float_1(query *q);
 bool bif_iso_integer_1(query *q);
 
 bool do_yield(query *q, int msecs);
+bool do_yield_then(query *q, bool status);
 void do_yield_at(query *q, unsigned int time_in_ms);
 
 inline static void init_queuen(query *q)
@@ -337,4 +338,3 @@ inline static bool START_FUNCTION(query *q)
 
 	return false;
 }
-

--- a/src/print.c
+++ b/src/print.c
@@ -1558,9 +1558,6 @@ char *print_term_to_strbuf(query *q, cell *c, pl_idx c_ctx, int running)
 
 bool print_term_to_stream(query *q, stream *str, cell *c, pl_idx c_ctx, int running)
 {
-	if (q->retry)
-		return true;
-
 	q->did_quote = false;
 	q->last_thing = WAS_SPACE;
 	SB_init(q->sb);

--- a/src/query.c
+++ b/src/query.c
@@ -1646,7 +1646,7 @@ bool start(query *q)
 					uint64_t now = get_time_in_usec() / 1000;
 
 					if (now > q->yield_at)  {
-						do_yield(q, 0);
+						do_yield_then(q, status);
 						break;
 					}
 				}


### PR DESCRIPTION
(Fixes #569)

Background:
`pl_yield_at` is used by the JS port to periodically yield to the main thread, this prevents the browser UI locking up. Previously, this caused the last goal executed before yielding to be run twice, and I think also potentially succeeding when it should have failed. This could cause the JSON-based toplevel to become corrupt among other things.

This PR tweaks it so that the goal is only run once, and a matching succeed or fail choice point can be resumed from.
I ran these changes overnight and tested it against some previously flaky cases I had lying around, and it looks good now. I'm happy to finally figure out what was going on with that.

Also reverts some stuff that is not needed anymore discussed in #569. Feel free to rename this stuff, couldn't think of a good function name.