### PR TITLE
Use libc qsort_r for WASI build (re: #575)

### DIFF
--- a/src/bif_sort.c
+++ b/src/bif_sort.c
@@ -42,6 +42,11 @@ static int nodecmp(const void *ptr1, const void *ptr2)
 		return ok < 0 ? 1 : ok > 0 ? -1 : 0;
 }
 
+static int nodecmp_(const void *ptr1, const void *ptr2, const void *data)
+{
+	return nodecmp(ptr1, ptr2);
+}
+
 static cell *nodesort(query *q, cell *p1, pl_idx p1_ctx, bool dedup, bool keysort, bool *status)
 {
 	pl_int max = PL_INT_MAX, skip = 0;
@@ -81,7 +86,7 @@ static cell *nodesort(query *q, cell *p1, pl_idx p1_ctx, bool dedup, bool keysor
 		p1_ctx = q->latest_ctx;
 	}
 
-	sort_r(base, cnt, sizeof(basepair), (void*)nodecmp, NULL);
+	sort_r(base, cnt, sizeof(basepair), (void*)nodecmp_, NULL);
 
 	for (size_t i = 0; i < cnt; i++) {
 		if (i > 0) {
@@ -260,7 +265,7 @@ static cell *nodesort4(query *q, cell *p1, pl_idx p1_ctx, bool dedup, bool ascen
 		p1_ctx = q->latest_ctx;
 	}
 
-	sort_r(base, cnt, sizeof(basepair), (void*)nodecmp, NULL);
+	sort_r(base, cnt, sizeof(basepair), (void*)nodecmp_, NULL);
 
 	for (size_t i = 0; i < cnt; i++) {
 		if (i > 0) {

--- a/src/sort_r.h
+++ b/src/sort_r.h
@@ -27,7 +27,7 @@ void sort_r(void *base, size_t nel, size_t width,
 #if (defined __APPLE__ || defined __MACH__ || defined __DARWIN__ || \
      (defined __FreeBSD__ && !defined(qsort_r)) || defined __DragonFly__)
 #  define _SORT_R_BSD
-#elif (defined __GLIBC__ || (defined (__FreeBSD__) && defined(qsort_r)))
+#elif (defined __GLIBC__ || (defined (__FreeBSD__) && defined(qsort_r)) || defined __wasi__)
 #  define _SORT_R_LINUX
 #elif (defined _WIN32 || defined _WIN64 || defined __WINDOWS__ || \
        defined __MINGW32__ || defined __MINGW64__)


### PR DESCRIPTION
This fixes the clpz issues for the wasm build outlined in #575. The qsort_r built into wasi-libc seems to do the trick.

I added `nodecmp_` because some wasm runtimes will get mad if you pass a function pointer with too few arguments, wasn't sure what to call it.