### PR TITLE
CI: update packages before build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -24,10 +24,12 @@
             fetch-depth: 0
         - name: Install deps (Linux)
           run: |
+            sudo apt-get update
             sudo apt-get install libreadline-dev xxd libffi-dev libssl-dev
           if: matrix.os == 'ubuntu-latest'
         - name: Install deps (macOS)
           run: |
+            brew update
             brew install readline vim libffi openssl make
             echo "$(brew --prefix)/opt/make/libexec/gnubin" >> $GITHUB_PATH
           if: matrix.os == 'macos-latest'


### PR DESCRIPTION
Oops, I left this out. It should fix the spurious build errors (404 errors) in GitHub Actions from today.