### PR TITLE
Do not yield_at if a hook is pending

### DIFF
--- a/src/query.c
+++ b/src/query.c
@@ -1653,7 +1653,7 @@ bool start(query *q)
 				if (!(q->s_cnt++ % 100))
 					check_pressure(q);
 
-				if (q->yield_at) {
+				if (q->yield_at && !q->run_hook) {
 					uint64_t now = get_time_in_usec() / 1000;
 
 					if (now > q->yield_at)  {


### PR DESCRIPTION
This only affected the JS library, but it could, if you were very unlucky, yield here and accidentally skip a hook.