### PR TITLE
Update GHA artifact action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@
         - name: Test
           run: make test
         - name: Upload artifacts
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: ${{ format('tpl-{0}-{1}', runner.os, runner.arch) }}
             path: |
@@ -89,7 +89,7 @@
             mv ATTRIBUTION ATTRIBUTION.txt
             mv LICENSE LICENSE.txt
         - name: Upload artifacts
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: ${{ format('tpl-{0}-{1}', runner.os, runner.arch) }}
             path: |
@@ -145,7 +145,7 @@
             chmod +x tpl
             make test
         - name: Upload artifacts
-          uses: actions/upload-artifact@v3
+          uses: actions/upload-artifact@v4
           with:
             name: tpl-wasm-wasi
             path: |
@@ -161,7 +161,7 @@
       runs-on: ubuntu-latest
       steps:
         - name: Download artifacts
-          uses: actions/download-artifact@v3
+          uses: actions/download-artifact@v4
           with:
             path: artifacts
         - name: List files


### PR DESCRIPTION
Release script was failing because GitHub deprecated their v3 artifact stuff, bumping it to v4 should fix things.