### PR TITLE
Add missing dependency in apt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Written in plain-old C99.
 
 On Debian+ systems you may need to install GNU readline, xxd & libffi
 
-	sudo apt install libreadline-dev xxd libffi-dev
+	sudo apt install libreadline-dev xxd libffi-dev libssl-dev
 
 Then...
 


### PR DESCRIPTION
Hi,

This adds a missing dependency to the README that I needed to also install with `apt` on Debian in order to be able to run `make`.

This was tested in a fresh Debian podman container via [distrobox](https://distrobox.it/).