### PR TITLE
Rename tot to total

### DIFF
--- a/src/bif_control.c
+++ b/src/bif_control.c
@@ -36,7 +36,7 @@ bool bif_sys_cut_1(query *q)
 
 bool bif_iso_conjunction_2(query *q)
 {
-	q->tot_inferences--;
+	q->total_inferences--;
 	q->retry = QUERY_NOOP;
 	q->st.instr++;
 	return true;
@@ -44,7 +44,7 @@ bool bif_iso_conjunction_2(query *q)
 
 static bool bif_sys_cleanup_if_det_1(query *q)
 {
-	q->tot_inferences--;
+	q->total_inferences--;
 	GET_FIRST_RAW_ARG(p1,integer)
 	choice *ch = GET_CURR_CHOICE();
 
@@ -671,7 +671,7 @@ bool bif_sys_get_level_1(query *q)
 bool bif_sys_drop_barrier_1(query *q)
 {
 	GET_FIRST_ARG(p1,integer)
-	q->tot_inferences--;
+	q->total_inferences--;
 	drop_barrier(q, get_smalluint(p1));
 
 	if (q->cp) {

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -100,7 +100,7 @@ static bool bif_clause_3(query *q)
 			break;
 
 		q->retry = QUERY_RETRY;
-		q->tot_backtracks++;
+		q->total_backtracks++;
 		retry_choice(q);
 	}
 
@@ -169,7 +169,7 @@ static bool bif_iso_clause_2(query *q)
 		}
 
 		q->retry = QUERY_RETRY;
-		q->tot_backtracks++;
+		q->total_backtracks++;
 		retry_choice(q);
 	}
 
@@ -283,7 +283,7 @@ static bool bif_iso_retractall_1(query *q)
 		}
 
 		q->retry = QUERY_RETRY;
-		q->tot_backtracks++;
+		q->total_backtracks++;
 		retry_choice(q);
 	}
 

--- a/src/bif_os.c
+++ b/src/bif_os.c
@@ -310,17 +310,17 @@ static bool bif_busy_1(query *q)
 static bool bif_sys_timer_0(query *q)
 {
 	q->st.timer_started = get_time_in_usec();
-	q->tot_inferences = 0;
+	q->total_inferences = 0;
 	return true;
 }
 
 static bool bif_sys_elapsed_0(query *q)
 {
-	q->tot_inferences--;
+	q->total_inferences--;
 	uint64_t elapsed = get_time_in_usec();
 	elapsed -= q->st.timer_started;
-	double lips = (1.0 / ((double)elapsed/1000/1000)) * q->tot_inferences;
-	fprintf(stderr, "%% Time elapsed %.3fs, %llu Inferences, %.3f MLips\n", (double)elapsed/1000/1000, (unsigned long long)q->tot_inferences, lips/1000/1000);
+	double lips = (1.0 / ((double)elapsed/1000/1000)) * q->total_inferences;
+	fprintf(stderr, "%% Time elapsed %.3fs, %llu Inferences, %.3f MLips\n", (double)elapsed/1000/1000, (unsigned long long)q->total_inferences, lips/1000/1000);
 	if (q->is_redo) fprintf(stdout, "  ");
 	return true;
 }

--- a/src/bif_predicates.c
+++ b/src/bif_predicates.c
@@ -3197,12 +3197,12 @@ bool bif_statistics_0(query *q)
 		"TCOs:%"PRIu64", "
 		"Frame recovs:%"PRIu64", "
 		"Queue: %u\n",
-		q->tot_inferences, q->tot_matches, q->tot_matched,
+		q->total_inferences, q->total_matches, q->total_matched,
 		q->hw_frames, q->hw_choices, q->hw_trails, q->hw_slots,
 		q->hw_heap_num,
 		q->st.fp, q->cp, q->st.tp, q->st.sp,
 		q->st.heap_num,
-		q->tot_backtracks, q->tot_retries, q->tot_tcos, q->tot_recovs,
+		q->total_backtracks, q->total_retries, q->total_tcos, q->total_recovs,
 		(unsigned)q->qcnt[q->st.qnum]
 		);
 	return true;

--- a/src/internal.h
+++ b/src/internal.h
@@ -685,8 +685,8 @@ struct query_ {
 	stringbuf sb_buf;
 	char tmpbuf[256];
 	bool ignores[MAX_IGNORES];
-	uint64_t tot_goals, tot_backtracks, tot_retries, tot_matches, tot_inferences;
-	uint64_t tot_tcos, tot_recovs, tot_matched;
+	uint64_t total_goals, total_backtracks, total_retries, total_matches, total_inferences;
+	uint64_t total_tcos, total_recovs, total_matched;
 	uint64_t step, qid, tmo_msecs, chgen, cycle_error;
 	uint64_t get_started, autofail_n, yield_at;
 	uint64_t cpu_started, time_cpu_last_started, future;
@@ -697,7 +697,7 @@ struct query_ {
 	pl_idx frames_size, slots_size, trails_size, choices_size;
 	pl_idx hw_choices, hw_frames, hw_slots, hw_trails, hw_heap_num;
 	pl_idx cp, before_hook_tp, qcnt[MAX_QUEUES], ball_ctx, cont_ctx;
-	pl_idx heap_size, tmph_size, tot_heaps, tot_heapsize;
+	pl_idx heap_size, tmph_size, total_heaps, total_heapsize;
 	pl_idx undo_lo_tp, undo_hi_tp;
 	pl_idx q_size[MAX_QUEUES], tmpq_size[MAX_QUEUES], qp[MAX_QUEUES];
 	prolog_flags flags;

--- a/src/query.c
+++ b/src/query.c
@@ -610,7 +610,7 @@ static void trim_frame(query *q, const frame *f)
 
 void undo_me(query *q)
 {
-	q->tot_retries++;
+	q->total_retries++;
 	const choice *ch = GET_CURR_CHOICE();
 
 	while (q->st.tp > ch->st.tp) {
@@ -631,7 +631,7 @@ void try_me(query *q, unsigned num_vars)
 	f->base = q->st.sp;
 	slot *e = GET_SLOT(f, 0);
 	memset(e, 0, sizeof(slot)*num_vars);
-	q->tot_matches++;
+	q->total_matches++;
 }
 
 static void push_frame(query *q)
@@ -672,7 +672,7 @@ static void reuse_frame(query *q, unsigned num_vars)
 	f->no_recov = false;
 	q->st.sp = f->base + f->actual_slots;
 	q->st.dbe->tcos++;
-	q->tot_tcos++;
+	q->total_tcos++;
 	q->st.hp = f->hp;
 	q->st.heap_num = f->heap_num;
 	trim_heap(q);
@@ -690,7 +690,7 @@ static bool commit_any_choices(const query *q, const frame *f)
 static void commit_frame(query *q)
 {
 	q->st.dbe->matched++;
-	q->tot_matched++;
+	q->total_matched++;
 
 	clause *cl = &q->st.dbe->cl;
 	frame *f = GET_CURR_FRAME();
@@ -998,7 +998,7 @@ static bool resume_frame(query *q)
 		&& (q->st.fp == (q->st.curr_frame + 1))
 		&& !resume_any_choices(q, f)
 		) {
-		q->tot_recovs++;
+		q->total_recovs++;
 		q->st.hp = f->hp;
 		q->st.heap_num = f->heap_num;
 		trim_heap(q);
@@ -1645,10 +1645,10 @@ bool start(query *q)
 		cell *save_cell = q->st.instr;
 		pl_idx save_ctx = q->st.curr_frame;
 		q->cycle_error = q->did_throw = false;
-		q->tot_goals++;
+		q->total_goals++;
 
 		if (is_builtin(q->st.instr)) {
-			q->tot_inferences++;
+			q->total_inferences++;
 			bool status;
 
 #if USE_FFI
@@ -1666,7 +1666,7 @@ bool start(query *q)
 				continue;
 			}
 
-			if (!(q->tot_goals % YIELD_INTERVAL)) {
+			if (!(q->total_goals % YIELD_INTERVAL)) {
 				q->s_cnt = 0;
 
 				if (!(q->s_cnt++ % 10000))
@@ -1689,7 +1689,7 @@ bool start(query *q)
 				if (q->yielded)
 					break;
 
-				q->tot_backtracks++;
+				q->total_backtracks++;
 				continue;
 			}
 
@@ -1702,19 +1702,19 @@ bool start(query *q)
 			if (!consultall(q, q->st.instr, q->st.curr_frame)) {
 				Trace(q, q->st.instr, q->st.curr_frame, FAIL);
 				q->retry = QUERY_RETRY;
-				q->tot_backtracks++;
+				q->total_backtracks++;
 				continue;
 			}
 
 			Trace(q, save_cell, save_ctx, EXIT);
 			proceed(q);
 		} else {
-			q->tot_inferences++;
+			q->total_inferences++;
 
 			if (!match_head(q)) {
 				Trace(q, q->st.instr, q->st.curr_frame, FAIL);
 				q->retry = QUERY_RETRY;
-				q->tot_backtracks++;
+				q->total_backtracks++;
 				continue;
 			}
 


### PR DESCRIPTION
Hi @infradig 

This PR just renames `tot` to `total` as discussed in https://github.com/trealla-prolog/trealla/discussions/732

I renamed all the struct fields that use `tot` instead of `total`. Some of them are unused in the codebase.

`make test` and `make check` pass fine locally.

There are two test failures but those are expected?

```
============
TEST SUMMARY
============
Failed: 2
Succeeded: 233
```