### PR TITLE
Add full apt install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Written in plain-old C99.
 
 On Debian+ systems you may need to install GNU readline, xxd & libffi
 
-	sudo apt install libreadline-dev libffi-dev libssl-dev xxd
+	sudo apt install build-essential git libreadline-dev libffi-dev libssl-dev xxd
 
 Then...
 


### PR DESCRIPTION
Hi,

This just adds the full required packages needed for a successful build to the README.

`build-essential` and `git` was needed to run `make` successfully.