### PR TITLE
Enable macro information in debug target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,7 +184,7 @@ profile:
 	$(MAKE) 'OPT=$(OPT) -O0 -pg -DDEBUG'
 
 debug:
-	$(MAKE) 'OPT=$(OPT) -O0 -g -DDEBUG'
+	$(MAKE) 'OPT=$(OPT) -O0 -g3 -DDEBUG'
 
 release:
 	$(MAKE) 'OPT=$(OPT) -DNDEBUG'


### PR DESCRIPTION
Hi,

This just enables the macro information to be included in the debug output in gdb so that the `macro expand` gdb subcommand works:

![image](https://github.com/user-attachments/assets/58d7aecc-6124-4e4c-bef3-d631ee0f2578)
