### PR TITLE
Fix wasm build errors

### DIFF
--- a/src/bif_threads.c
+++ b/src/bif_threads.c
@@ -12,17 +12,6 @@
 #include "query.h"
 
 #if USE_THREADS
-static void msleep(int ms)
-{
-	struct timespec tv = {0};
-	tv.tv_sec = (ms) / 1000;
-	tv.tv_nsec = ((ms) % 1000) * 1000 * 1000;
-	nanosleep(&tv, &tv);
-}
-
-#define is_thread_only(t) (!(t)->is_queue_only && !(t)->is_mutex_only)
-
-#if USE_THREADS
 
 void init_lock(lock *l)
 {
@@ -60,6 +49,17 @@ void acquire_lock(lock *l) {}
 void release_lock(lock *l) {}
 
 #endif
+
+#if USE_THREADS
+static void msleep(int ms)
+{
+	struct timespec tv = {0};
+	tv.tv_sec = (ms) / 1000;
+	tv.tv_nsec = ((ms) % 1000) * 1000 * 1000;
+	nanosleep(&tv, &tv);
+}
+
+#define is_thread_only(t) (!(t)->is_queue_only && !(t)->is_mutex_only)
 
 typedef struct msg_ {
 	lnode hdr;						// must be first


### PR DESCRIPTION
This rearranges the definition of the lock functions so that NOTHREADS builds can still see the symbols.