### PR TITLE
Fix argument mismatch in WASI qsort

### DIFF
--- a/src/bif_sort.c
+++ b/src/bif_sort.c
@@ -87,7 +87,7 @@ static cell *nodesort(query *q, cell *p1, pl_idx p1_ctx, bool dedup, bool keysor
 	|| defined __FreeBSD__ || defined __DragonFly__)
 	mergesort(base, cnt, sizeof(basepair), (void*)nodecmp_);
 #else
-	qsort(base, cnt, sizeof(basepair), (void*)nodecmp_);
+	qsort(base, cnt, sizeof(basepair), (void*)nodecmp);
 #endif
 
 	for (size_t i = 0; i < cnt; i++) {


### PR DESCRIPTION
With the recent sort changes we get something like this:
```
  RuntimeError: null function or function signature mismatch
      at libtpl-js.wasm.wrapper_cmp (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[1586]:0x414158)
      at libtpl-js.wasm.sift (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[1583]:0x413c78)
      at libtpl-js.wasm.__qsort_r (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[1582]:0x4139d2)
      at libtpl-js.wasm.qsort (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[1585]:0x414149)
      at libtpl-js.wasm.nodesort (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[567]:0x1f6774)
      at libtpl-js.wasm.bif_iso_sort_2 (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[564]:0x1f5b65)
      at libtpl-js.wasm.start (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[1116]:0x3cc16d)
      at libtpl-js.wasm.execute (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[1126]:0x3ce4e8)
      at libtpl-js.wasm.term_expansion (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[951]:0x323f01)
      at libtpl-js.wasm.tokenize (wasm://wasm/libtpl-js.wasm-01a681f2:wasm-function[948]:0x2fd137)
```

Luckily the change is simple, wasm is just fussy about extra/missing arguments.