### PR TITLE
fix minor compiler warnings to prepare for Makefile changes

### DIFF
--- a/src/bif_predicates.c
+++ b/src/bif_predicates.c
@@ -3,6 +3,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <string.h>
+#include <unistd.h>
 
 #include "base64.h"
 #include "module.h"

--- a/src/trealla.h
+++ b/src/trealla.h
@@ -6,7 +6,7 @@
 typedef struct prolog_ prolog;
 typedef struct {} pl_sub_query;
 
-prolog *pl_create();
+prolog *pl_create(void);
 void pl_destroy(prolog*);
 
 bool pl_consult(prolog*, const char *filename);


### PR DESCRIPTION
`src/bif_predicates.c`: `unistd.h` needed to pull in `getpid()`
`src/trealla.h`: fixes empty prototype warning