### PR TITLE
fix make install

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -188,7 +188,7 @@ release:
 	$(MAKE) 'OPT=$(OPT) -DNDEBUG'
 
 install:
-	ln -s ./tpl ~/bin/tpl
+	ln -s $(PWD)/tpl ~/bin/tpl
 
 tpl.wasm:
 	$(MAKE) WASI=1 'OPT=$(OPT) -DNDEBUG'


### PR DESCRIPTION
otherwise the symbolic link would point ./tpl in the dir the symbolic link is in (~/bin) i.e. /bin/tpl. Instead the symbolic links needs to point to where the build tpl executable actually is which is ${PWD} of where I run the `make install` command.