### PR TITLE
Rename ensure Macro

### DIFF
--- a/src/bif_threads.c
+++ b/src/bif_threads.c
@@ -173,7 +173,7 @@ static int new_thread(prolog *pl)
 void thread_initialize(prolog *pl)
 {
 	int n = new_thread(pl);
-	ensure(n >= 0);
+	ENSURE(n >= 0);
 	thread *t = &pl->threads[n];
 	if (!t->alias) t->alias = sl_create((void*)fake_strcmp, (void*)keyfree, NULL);
 	sl_app(t->alias, strdup("main"), NULL);
@@ -540,7 +540,7 @@ static void do_unlock_all(prolog *pl)
 static void *start_routine_thread(thread *t)
 {
 	prolog *pl = pl_create();
-	ensure(pl);
+	ENSURE(pl);
 	pl->my_chan = t->chan;
 	pl_consult(pl, t->filename);
 	t->is_active = false;
@@ -853,7 +853,7 @@ bool do_signal(query *q, void *thread_ptr)
 	unshare_cells(c, c->num_cells);
 	free(m);
 	cell *tmp = prepare_call(q, CALL_NOSKIP, c, q->st.cur_ctx, 1);
-	ensure(tmp);
+	ENSURE(tmp);
 	pl_idx num_cells = c->num_cells;
 	make_call(q, tmp+num_cells);
 	q->st.instr = tmp;

--- a/src/history.c
+++ b/src/history.c
@@ -74,7 +74,7 @@ LOOP:
 	if (cmd) {
 		size_t n = strlen(cmd) + strlen(line);
 		cmd = realloc(cmd, n+1);
-		ensure(cmd);
+		ENSURE(cmd);
 		strcat(cmd, line);
 	} else {
 		cmd = strdup(line);
@@ -108,7 +108,7 @@ LOOP:
 
 		if (ch == 0) {
 			cmd = realloc(cmd, strlen(cmd)+1+1);
-			ensure(cmd);
+			ENSURE(cmd);
 			strcat(cmd, "\n");
 			prompt = "";
 			goto LOOP;
@@ -332,7 +332,7 @@ LOOP:
 	if (cmd) {
 		size_t n = strlen(cmd) + strlen(line);
 		cmd = realloc(cmd, n+1);
-		ensure(cmd);
+		ENSURE(cmd);
 		strcat(cmd, line);
 	} else {
 		cmd = strdup(line);
@@ -357,7 +357,7 @@ LOOP:
 
 		if (ch == 0) {
 			cmd = realloc(cmd, strlen(cmd)+1+1);
-			ensure(cmd);
+			ENSURE(cmd);
 			strcat(cmd, "\n");
 			prompt = "";
 			goto LOOP;

--- a/src/internal.h
+++ b/src/internal.h
@@ -1076,5 +1076,5 @@ inline static void predicate_delink(predicate *pr, rule *r)
 	if (pr->tail == r) pr->tail = r->prev;
 }
 
-#define ensure(cond, ...) if (!(cond)) { printf("Error: no memory %s %d\n", __FILE__, __LINE__); abort(); }
+#define ENSURE(cond, ...) if (!(cond)) { printf("Error: no memory %s %d\n", __FILE__, __LINE__); abort(); }
 

--- a/src/module.c
+++ b/src/module.c
@@ -131,7 +131,7 @@ static const char *set_known(module *m, const char *filename)
 	}
 
 	ptr = malloc(sizeof(loaded_file));
-	ensure(ptr);
+	ENSURE(ptr);
 	ptr->next = m->loaded_files;
 	ptr->orig_filename = strdup(filename);
 	ptr->filename = strdup(filename);
@@ -155,7 +155,7 @@ static const char *set_loaded(module *m, const char *filename, const char *orig_
 	}
 
 	ptr = malloc(sizeof(loaded_file));
-	ensure(ptr);
+	ENSURE(ptr);
 	ptr->next = m->loaded_files;
 	ptr->orig_filename = strdup(orig_filename);
 	ptr->filename = strdup(filename);
@@ -365,7 +365,7 @@ predicate *create_predicate(module *m, cell *c, bool *created)
 	}
 
 	predicate *pr = calloc(1, sizeof(predicate));
-	ensure(pr);
+	ENSURE(pr);
 	list_push_back(&m->predicates, pr);
 
 	if (created)
@@ -476,7 +476,7 @@ void create_goal_expansion(module *m, cell *c)
 		return;
 
 	pi *g = calloc(1, sizeof(pi));
-	ensure(g);
+	ENSURE(g);
 	g->prev = m->gex_tail;
 
 	if (m->gex_tail)
@@ -788,7 +788,7 @@ void set_discontiguous_in_db(module *m, const char *name, unsigned arity)
 	cell tmp = (cell){0};
 	tmp.tag = TAG_INTERNED;
 	tmp.val_off = new_atom(m->pl, name);
-	ensure(tmp.val_off != ERR_IDX);
+	ENSURE(tmp.val_off != ERR_IDX);
 	tmp.arity = arity;
 	predicate *pr = find_predicate(m, &tmp);
 	if (!pr) pr = create_predicate(m, &tmp, NULL);
@@ -805,7 +805,7 @@ void set_multifile_in_db(module *m, const char *name, pl_idx arity)
 	cell tmp = (cell){0};
 	tmp.tag = TAG_INTERNED;
 	tmp.val_off = new_atom(m->pl, name);
-	ensure(tmp.val_off != ERR_IDX);
+	ENSURE(tmp.val_off != ERR_IDX);
 	tmp.arity = arity;
 	predicate *pr = find_predicate(m, &tmp);
 	if (!pr) pr = create_predicate(m, &tmp, NULL);
@@ -822,7 +822,7 @@ void set_dynamic_in_db(module *m, const char *name, unsigned arity)
 	cell tmp = (cell){0};
 	tmp.tag = TAG_INTERNED;
 	tmp.val_off = new_atom(m->pl, name);
-	ensure(tmp.val_off != ERR_IDX);
+	ENSURE(tmp.val_off != ERR_IDX);
 	tmp.arity = arity;
 	predicate *pr = find_predicate(m, &tmp);
 	if (!pr) pr = create_predicate(m, &tmp, NULL);
@@ -841,7 +841,7 @@ void set_meta_predicate_in_db(module *m, cell *c)
 	cell tmp = (cell){0};
 	tmp.tag = TAG_INTERNED;
 	tmp.val_off = new_atom(m->pl, name);
-	ensure(tmp.val_off != ERR_IDX);
+	ENSURE(tmp.val_off != ERR_IDX);
 	tmp.arity = arity;
 	predicate *pr = find_predicate(m, &tmp);
 	if (!pr) pr = create_predicate(m, &tmp, NULL);
@@ -946,7 +946,7 @@ static bool do_use_module(module *curr_m, cell *c, module **mptr)
 				continue;
 
 			char *src = malloc(*lib->len+1);
-			ensure(src);
+			ENSURE(src);
 			memcpy(src, lib->start, *lib->len);
 			src[*lib->len] = '\0';
 			SB(s1);
@@ -978,7 +978,7 @@ static bool do_use_module(module *curr_m, cell *c, module **mptr)
 			continue;
 
 		char *src = malloc(*lib->len+1);
-		ensure(src);
+		ENSURE(src);
 		memcpy(src, lib->start, *lib->len);
 		src[*lib->len] = '\0';
 		SB(s1);
@@ -1274,7 +1274,7 @@ static bool set_op_internal(module *m, const char *name, unsigned specifier, uns
 
 	sl_done(iter);
 	op_table *tmp = malloc(sizeof(op_table));
-	ensure(tmp);
+	ENSURE(tmp);
 	tmp->name = set_known(m, name);
 	tmp->priority = priority;
 	tmp->specifier = specifier;
@@ -1945,7 +1945,7 @@ static rule *assert_begin(module *m, unsigned num_vars, cell *p1, bool consultin
 
 	size_t dbe_size = sizeof(rule) + (sizeof(cell) * (p1->num_cells+1));
 	rule *r = calloc(1, dbe_size);
-	ensure(r);
+	ENSURE(r);
 	copy_cells(r->cl.cells, p1, p1->num_cells);
 	r->cl.cells[p1->num_cells] = (cell){0};
 	r->cl.cells[p1->num_cells].tag = TAG_END;
@@ -1979,11 +1979,11 @@ static void assert_commit(module *m, rule *r, predicate *pr, bool append)
 			return;
 
 		pr->idx1 = sl_create(index_cmpkey, NULL, m);
-		ensure(pr->idx1);
+		ENSURE(pr->idx1);
 
 		if (pr->key.arity > 1) {
 			pr->idx2 = sl_create(index_cmpkey, NULL, m);
-			ensure(pr->idx2);
+			ENSURE(pr->idx2);
 		}
 
 		for (rule *cl2 = pr->head; cl2; cl2 = cl2->next) {
@@ -2206,7 +2206,7 @@ bool unload_file(module *m, const char *filename)
 {
 	size_t len = strlen(filename);
 	char *tmpbuf = malloc(len + 20);
-	ensure(tmpbuf);
+	ENSURE(tmpbuf);
 	memcpy(tmpbuf, filename, len+1);
 
 	if (tmpbuf[0] == '~') {
@@ -2214,7 +2214,7 @@ bool unload_file(module *m, const char *filename)
 
 		if (ptr) {
 			tmpbuf = realloc(tmpbuf, strlen(ptr) + 10 + strlen(filename) + 20);
-			ensure(tmpbuf);
+			ENSURE(tmpbuf);
 			strcpy(tmpbuf, ptr);
 			strcat(tmpbuf, filename+1);
 			convert_path(tmpbuf);
@@ -2482,7 +2482,7 @@ module *load_file(module *m, const char *filename, bool including, bool init)
 
 	if ((st.st_mode & S_IFMT) == S_IFDIR) {
 		char *tmpbuf = malloc(strlen(orig_filename)+20);
-		ensure(tmpbuf);
+		ENSURE(tmpbuf);
 		strcpy(tmpbuf, orig_filename);
 		strcat(tmpbuf, ".pl");
 		m = load_file(m, tmpbuf, including, init);
@@ -2604,7 +2604,7 @@ void module_duplicate(prolog *pl, module *m, const char *name, unsigned arity)
 module *module_create(prolog *pl, const char *name)
 {
 	module *m = calloc(1, sizeof(module));
-	ensure(m);
+	ENSURE(m);
 
 	m->pl = pl;
 	m->filename = set_known(m, name);
@@ -2622,7 +2622,7 @@ module *module_create(prolog *pl, const char *name)
 	if (strcmp(name, "system")) {
 		for (const op_table *ptr = g_ops; ptr->name; ptr++) {
 			op_table *tmp = malloc(sizeof(op_table));
-			ensure(tmp);
+			ENSURE(tmp);
 			memcpy(tmp, ptr, sizeof(op_table));
 			sl_app(m->defops, tmp->name, tmp);
 		}

--- a/src/network.c
+++ b/src/network.c
@@ -425,7 +425,7 @@ int net_getline(char **lineptr, size_t *n, stream *str)
 	if (str->ssl) {
 		if (!*lineptr) {
 			*lineptr = malloc(*n=1024);
-			ensure(*lineptr);
+			ENSURE(*lineptr);
 		}
 
 		char *dst = *lineptr;
@@ -452,7 +452,7 @@ int net_getline(char **lineptr, size_t *n, stream *str)
 					size_t savelen = dst - *lineptr;
 					*n *= 2;
 					*lineptr = realloc(*lineptr, *n);
-					ensure(*lineptr);
+					ENSURE(*lineptr);
 					dst = *lineptr + savelen;
 					dstlen = *n - savelen;
 				}

--- a/src/parser.c
+++ b/src/parser.c
@@ -27,7 +27,7 @@ bool is_graphic(int ch)
 char *slicedup(const char *s, size_t n)
 {
 	char *ptr = malloc(n+1);
-	ensure (ptr);
+	ENSURE (ptr);
 	memcpy(ptr, s, n);
 	ptr[n] = '\0';
 	return ptr;
@@ -342,7 +342,7 @@ static bool make_room(parser *p, unsigned num)
 		pl_idx num_cells = (p->cl->num_allocated_cells + num) * 3 / 2;
 
 		clause *cl = realloc(p->cl, sizeof(clause)+(sizeof(cell)*num_cells));
-		ensure(cl);
+		ENSURE(cl);
 		p->cl = cl;
 		p->cl->num_allocated_cells = num_cells;
 	}
@@ -395,12 +395,12 @@ void parser_destroy(parser *p)
 parser *parser_create(module *m)
 {
 	parser *p = calloc(1, sizeof(parser));
-	ensure(p);
+	ENSURE(p);
 	p->pl = m->pl;
 	p->m = m;
 	pl_idx num_cells = INITIAL_NBR_CELLS;
 	p->cl = calloc(1, sizeof(clause)+(sizeof(cell)*num_cells));
-	ensure(p->cl, free(p));
+	ENSURE(p->cl, free(p));
 	p->cl->num_allocated_cells = num_cells;
 	p->start_term = true;
 	p->flags = m->flags;
@@ -431,7 +431,7 @@ static void consultall(parser *p, cell *l)
 char *relative_to(const char *basefile, const char *relfile)
 {
 	char *tmpbuf = malloc(strlen(basefile) + strlen(relfile) + 256);
-	ensure(tmpbuf);
+	ENSURE(tmpbuf);
 	char *ptr = tmpbuf;
 
 	if (!strncmp(relfile, "../", 3) || !strchr(relfile, '/')) {
@@ -754,7 +754,7 @@ static bool directives(parser *p, cell *d)
 		q.st.m = p->m;
 		char *dst = print_term_to_strbuf(&q, p1, p1_ctx, 0);
 		builtins *ptr = calloc(1, sizeof(builtins));
-		ensure(ptr);
+		ENSURE(ptr);
 		ptr->name = strdup(C_STR(p, p1));
 		ptr->arity = p1->arity;
 		ptr->m = p->m;
@@ -1592,7 +1592,7 @@ void assign_vars(parser *p, unsigned start, bool rebase)
 	}
 
 	cell *c = make_a_cell(p);
-	ensure(c);
+	ENSURE(c);
 	c->tag = TAG_END;
 	c->num_cells = 1;
 }
@@ -2868,7 +2868,7 @@ static bool parse_number(parser *p, const char **srcptr, bool neg)
 
 		if (mp_int_to_int(&v2, &val) == MP_RANGE) {
 			p->v.val_bigint = malloc(sizeof(bigint));
-			ensure(p->v.val_bigint);
+			ENSURE(p->v.val_bigint);
 			p->v.val_bigint->refcnt = 1;
 			mp_int_init_copy(&p->v.val_bigint->ival, &v2);
 			if (neg) p->v.val_bigint->ival.sign = MP_NEG;
@@ -2890,7 +2890,7 @@ static bool parse_number(parser *p, const char **srcptr, bool neg)
 
 		if (mp_int_to_int(&v2, &val) == MP_RANGE) {
 			p->v.val_bigint = malloc(sizeof(bigint));
-			ensure(p->v.val_bigint);
+			ENSURE(p->v.val_bigint);
 			p->v.val_bigint->refcnt = 1;
 			mp_int_init_copy(&p->v.val_bigint->ival, &v2);
 			if (neg) p->v.val_bigint->ival.sign = MP_NEG;
@@ -2912,7 +2912,7 @@ static bool parse_number(parser *p, const char **srcptr, bool neg)
 
 		if (mp_int_to_int(&v2, &val) == MP_RANGE) {
 			p->v.val_bigint = malloc(sizeof(bigint));
-			ensure(p->v.val_bigint);
+			ENSURE(p->v.val_bigint);
 			p->v.val_bigint->refcnt = 1;
 			mp_int_init_copy(&p->v.val_bigint->ival, &v2);
 			if (neg) p->v.val_bigint->ival.sign = MP_NEG;
@@ -2977,7 +2977,7 @@ static bool parse_number(parser *p, const char **srcptr, bool neg)
 
 	if (mp_int_to_int(&v2, &val) == MP_RANGE) {
 		p->v.val_bigint = malloc(sizeof(bigint));
-		ensure(p->v.val_bigint);
+		ENSURE(p->v.val_bigint);
 		p->v.val_bigint->refcnt = 1;
 		mp_int_init_copy(&p->v.val_bigint->ival, &v2);
 		if (neg) p->v.val_bigint->ival.sign = MP_NEG;
@@ -3859,7 +3859,7 @@ unsigned tokenize(parser *p, bool is_arg_processing, bool is_consing)
 		if (!p->quote_char && !SB_strcmp(p->token, "{")) {
 			save_idx = p->cl->cidx;
 			cell *c = make_interned(p, g_braces_s);
-			ensure(c);
+			ENSURE(c);
 			c->arity = 1;
 			p->start_term = true;
 			p->nesting_braces++;
@@ -4317,7 +4317,7 @@ unsigned tokenize(parser *p, bool is_arg_processing, bool is_consing)
 
 			if (!p->is_number_chars) {
 				c->val_off = new_atom(p->pl, SB_cstr(p->token));
-				ensure(c->val_off != ERR_IDX);
+				ENSURE(c->val_off != ERR_IDX);
 			}
 		} else {
 			c->tag = TAG_CSTR;

--- a/src/query.c
+++ b/src/query.c
@@ -1572,7 +1572,7 @@ static bool any_outstanding_choices(query *q)
 void do_cleanup(query *q, cell *c, pl_ctx c_ctx)
 {
 	cell *tmp = prepare_call(q, CALL_NOSKIP, c, c_ctx, 4);
-	ensure(tmp);
+	ENSURE(tmp);
 	pl_idx num_cells = c->num_cells;
 	make_instr(tmp+num_cells++, g_cut_s, bif_iso_cut_0, 0, 0);
 	make_instr(tmp+num_cells++, g_sys_drop_barrier_s, bif_sys_drop_barrier_1, 1, 1);
@@ -1867,7 +1867,7 @@ query *query_create(module *m)
 {
 	static pl_atomic uint64_t g_query_id = 0;
 	query *q = calloc(1, sizeof(query));
-	ensure(q);
+	ENSURE(q);
 	q->p = parser_create(m);
 	q->flags.occurs_check = false;
 	q->qid = g_query_id++;
@@ -1895,10 +1895,10 @@ query *query_create(module *m)
 	q->slots_size = INITIAL_NBR_SLOTS;
 	q->trails_size = INITIAL_NBR_TRAILS;
 
-	ensure(q->frames = calloc(q->frames_size, sizeof(frame)), NULL);
-	ensure(q->choices = calloc(q->choices_size, sizeof(choice)), NULL);
-	ensure(q->slots = calloc(q->slots_size, sizeof(slot)), NULL);
-	ensure(q->trails = calloc(q->trails_size, sizeof(trail)), NULL);
+	ENSURE(q->frames = calloc(q->frames_size, sizeof(frame)), NULL);
+	ENSURE(q->choices = calloc(q->choices_size, sizeof(choice)), NULL);
+	ENSURE(q->slots = calloc(q->slots_size, sizeof(slot)), NULL);
+	ENSURE(q->trails = calloc(q->trails_size, sizeof(trail)), NULL);
 
 	// Allocate these later as needed...
 

--- a/src/stringbuf.h
+++ b/src/stringbuf.h
@@ -19,7 +19,7 @@ typedef struct {
 #define SB_alloc(pr,len) stringbuf pr##_buf; 					\
 	pr##_buf.buf_size = len;									\
 	pr##_buf.buf = malloc((len)+1);								\
-	ensure(pr##_buf.buf);										\
+	ENSURE(pr##_buf.buf);										\
 	pr##_buf.dst = pr##_buf.buf;								\
 	*pr##_buf.dst = '\0';
 
@@ -36,7 +36,7 @@ typedef struct {
 			if (pr##_buf.buf) 									\
 				memcpy(pr##_buf.buf, pr##_buf.tmpbuf, offset+1);\
 		}														\
-		ensure(pr##_buf.buf);									\
+		ENSURE(pr##_buf.buf);									\
 		pr##_buf.dst = pr##_buf.buf + offset;					\
 	}															\
 }

--- a/src/terms.c
+++ b/src/terms.c
@@ -129,7 +129,7 @@ void collect_vars(query *q, cell *p1, pl_ctx p1_ctx)
 {
 	if (++q->vgen == 0) q->vgen = 1;
 	q->tab_idx = 0;
-	ensure(q->vars = sl_create(NULL, NULL, NULL));
+	ENSURE(q->vars = sl_create(NULL, NULL, NULL));
 	collect_vars_internal(q, p1, p1_ctx, 0);
 	sl_destroy(q->vars);
 	q->vars = NULL;

--- a/src/toplevel.c
+++ b/src/toplevel.c
@@ -278,7 +278,7 @@ static void	clear_results()
 static void add_result(int num, cell *c, pl_ctx c_ctx)
 {
 	item *ptr = malloc(sizeof(item));
-	ensure(ptr);
+	ENSURE(ptr);
 	ptr->c = c;
 	ptr->c_ctx = c_ctx;
 	ptr->num = num;


### PR DESCRIPTION
Hi,

This PR renames `ensure` to `ENSURE` in order to use the convention of upper casing macros.

I think this improves readability for new readers of the code.

I would be happy to open PRs for other similarly named macros so that we can follow one convention across all the code.

I feel that macros introduce additional complexity (make the code harder to debug, etc.) and make the code more opaque to read at times.

What do you think if we were to rewrite certain macros to not be macros where it makes sense? 