### PR TITLE
Refactor is_empty to be a function

### DIFF
--- a/src/internal.h
+++ b/src/internal.h
@@ -76,7 +76,6 @@ char *realpath(const char *path, char resolved_path[PATH_MAX]);
 
 // Primary type...
 
-#define is_empty(c) ((c)->tag == TAG_EMPTY)
 #define is_var(c) ((c)->tag == TAG_VAR)
 #define is_interned(c) ((c)->tag == TAG_INTERNED)
 #define is_cstring(c) ((c)->tag == TAG_CSTR)
@@ -1078,3 +1077,6 @@ inline static void predicate_delink(predicate *pr, rule *r)
 
 #define ENSURE(cond, ...) if (!(cond)) { printf("Error: no memory %s %d\n", __FILE__, __LINE__); abort(); }
 
+inline static bool is_empty(const cell *c) {
+	return c->tag == TAG_EMPTY;
+}


### PR DESCRIPTION
This is a proposal PR to make sure that I am going in the right direction with this.

I've only converted `is_empty`.

I realize that passing the `cell` as a pointer here avoids copying a potentially large instance of the `cell` struct on each call.

Since the `is_empty` function is only reading and not mutating, I annotated `cell` to be `const`.

@infradig Should I be annotating `is_empty` with the `inline` keyword? I see that is gets rid of a warning.