### PR TITLE
Feature/modular library embedding

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,8 @@ BINDIR ?= $(PREFIX)/bin
 LIBDIR ?= $(PREFIX)/share/trealla
 MANDIR ?= $(PREFIX)/share/man
 
+EMBED ?= 1
+
 HOST_CC ?= cc
 
 GIT_VERSION := "$(shell git describe --abbrev=4 --dirty --always --tags)"
@@ -16,6 +18,11 @@ CFLAGS = -Isrc -I/usr/local/include -DVERSION='$(GIT_VERSION)' \
 	-Wno-unused-but-set-variable \
 	-Wno-unused-parameter \
 	-Wno-unused-variable
+
+ifeq ($(EMBED), 1)
+CFLAGS += -DEMBED=1
+endif
+
 LDFLAGS = -L/usr/local/lib -lm
 
 ifdef HOMEBREW_PREFIX
@@ -126,6 +133,9 @@ SRCOBJECTS = tpl.o \
 	src/utf8.o \
 	src/version.o
 
+LIBOBJECTS =
+
+ifeq ($(EMBED), 1)
 LIBOBJECTS +=  \
 	library/abnf.o \
 	library/aggregate.o \
@@ -166,6 +176,7 @@ LIBOBJECTS +=  \
 	library/ugraphs.o \
 	library/uuid.o \
 	library/when.o
+endif
 
 SRCOBJECTS += src/imath/imath.o
 SRCOBJECTS += src/imath/imrat.o

--- a/src/library.c
+++ b/src/library.c
@@ -1,5 +1,6 @@
 #include "library.h"
 
+#ifdef EMBED
 extern unsigned char library_builtins_pl[];
 extern unsigned int library_builtins_pl_len;
 extern unsigned char library_lists_pl[];
@@ -131,3 +132,9 @@ library g_libs[] = {
 
 	 {0}
 };
+#else
+library g_libs[] = {
+	 {0}
+};
+#endif
+

--- a/src/prolog.c
+++ b/src/prolog.c
@@ -802,23 +802,48 @@ prolog *pl_create()
 
 	// Load some common libraries...
 
-	for (library *lib = g_libs; lib->name; lib++) {
-		if (!strcmp(lib->name, "builtins")
-			|| !strcmp(lib->name, "iso_ext")		// Common
-			|| !strcmp(lib->name, "dif")			// ???
-			) {
-			size_t len = *lib->len;
-			char *src = malloc(len+1);
-			check_error(src, pl_destroy(pl));
-			memcpy(src, lib->start, len);
-			src[len] = '\0';
+	const char *bootstrap[] = {"builtins", "iso_ext", "dif", NULL};
+
+	for (int i = 0; bootstrap[i]; i++) {
+		bool found = false;
+
+		for (library *lib = g_libs; lib->name; lib++) {
+			if (!strcmp(lib->name, bootstrap[i])) {
+				size_t len = *lib->len;
+				char *src = malloc(len+1);
+				check_error(src, pl_destroy(pl));
+				memcpy(src, lib->start, len);
+				src[len] = '\0';
+				SB(s1);
+				SB_sprintf(s1, "library/%s", lib->name);
+				module *m = load_text(pl->user_m, src, SB_cstr(s1));
+				m->prebuilt = true;
+				SB_free(s1);
+				free(src);
+				check_error(m, pl_destroy(pl));
+				found = true;
+				break;
+			}
+		}
+
+		if (!found) {
 			SB(s1);
-			SB_sprintf(s1, "library/%s", lib->name);
-			module *m = load_text(pl->user_m, src, SB_cstr(s1));
-			m->prebuilt = true;
+			SB_sprintf(s1, "%s/%s.pl", g_tpl_lib, bootstrap[i]);
+			module *m = load_file(pl->user_m, SB_cstr(s1), false, true);
+
+			if (!m || m->error) {
+				// Only builtins is absolutely required for now
+				if (!strcmp(bootstrap[i], "builtins")) {
+					fprintf(stderr, "Error: could not find library(%s) at %s\n", bootstrap[i], SB_cstr(s1));
+					SB_free(s1);
+					pl_destroy(pl);
+					return NULL;
+				}
+			} else {
+				m->prebuilt = true;
+			}
+
 			SB_free(s1);
-			free(src);
-			check_error(m, pl_destroy(pl));
 		}
 	}
 

--- a/src/prolog.c
+++ b/src/prolog.c
@@ -832,17 +832,13 @@ prolog *pl_create()
 			module *m = load_file(pl->user_m, SB_cstr(s1), false, true);
 
 			if (!m || m->error) {
-				// Only builtins is absolutely required for now
-				if (!strcmp(bootstrap[i], "builtins")) {
-					fprintf(stderr, "Error: could not find library(%s) at %s\n", bootstrap[i], SB_cstr(s1));
-					SB_free(s1);
-					pl_destroy(pl);
-					return NULL;
-				}
-			} else {
-				m->prebuilt = true;
+				fprintf(stderr, "Error: could not find library(%s) at %s\n", bootstrap[i], SB_cstr(s1));
+				SB_free(s1);
+				pl_destroy(pl);
+				return NULL;
 			}
 
+			m->prebuilt = true;
 			SB_free(s1);
 		}
 	}

--- a/tpl.c
+++ b/tpl.c
@@ -177,6 +177,16 @@ int main(int ac, char *av[], char * envp[])
 	int version = 0, daemon = 0;
 	bool no_res = false, quiet = false;
 	const char *restore_file = NULL;
+
+	for (i = 1; i < ac; i++) {
+		if (!strcmp(av[i], "--library")) {
+			if (++i < ac) {
+				g_tpl_lib = strdup(av[i]);
+				convert_path(g_tpl_lib);
+			}
+		}
+	}
+
 	prolog *pl = pl_create();
 
 	if (!pl) {


### PR DESCRIPTION
Added support for an `EMBED` build flag (default=1) to control whether bootstrap libraries are embedded or loaded from the filesystem.

Changes:
- Added `EMBED ?= 1` to Makefile
- Made library objects and `-DEMBED=1` conditional
- Wrapped embedded library data with `#ifdef EMBED` in `src/library.c`
- Updated bootstrap loading logic in `src/prolog.c`
- Parse `--library` option early in `tpl.c`

This allows building a lighter version that loads libraries externally when `EMBED=0`

#952 