### PR TITLE
Database simplification of clause, retract & retractall

### DIFF
--- a/library/iso_ext.pl
+++ b/library/iso_ext.pl
@@ -130,3 +130,43 @@ not(_).
 term_variables(P1, P2, P3) :-
 	term_variables(P1, P4),
 	append(P4, P3, P2).
+
+length(Xs0, N) :-
+   '$skip_max_list'(M, N, Xs0,Xs),
+   !,
+   (  Xs == [] -> N = M
+   ;  nonvar(Xs) -> var(N), Xs = [_|_], resource_error(finite_memory,length/2)
+   ;  nonvar(N) -> R is N-M, length_rundown(Xs, R)
+   ;  N == Xs -> failingvarskip(Xs), resource_error(finite_memory,length/2)
+   ;  length_addendum(Xs, N, M)
+   ).
+length(_, N) :-
+   integer(N), !,
+   domain_error(not_less_than_zero, N, length/2).
+length(_, N) :-
+   type_error(integer, N, length/2).
+
+length_rundown(Xs, 0) :- !, Xs = [].
+length_rundown(Vs, N) :-
+    '$unattributed_var'(Vs), % unconstrained
+    !,
+    '$det_length_rundown'(Vs, N).
+length_rundown([_|Xs], N) :- % force unification
+    N1 is N-1,
+    length(Xs, N1). % maybe some new info on Xs
+
+failingvarskip(Xs) :-
+    '$unattributed_var'(Xs), % unconstrained
+    !.
+failingvarskip([_|Xs0]) :- % force unification
+    '$skip_max_list'(_, _, Xs0,Xs),
+    (  nonvar(Xs) -> Xs = [_|_]
+	 ;  failingvarskip(Xs)
+    ).
+
+length_addendum([], N, N).
+length_addendum([_|Xs], N, M) :-
+    M1 is M + 1,
+    length_addendum(Xs, N, M1).
+
+:- help(length(?term,?integer), [iso(false), desc('Number of elements in list.')]).

--- a/library/lists.pl
+++ b/library/lists.pl
@@ -7,7 +7,7 @@
 		last/2, same_length/2, transpose/2,
 		sum_list/2, max_list/2, min_list/2,	% SWI
 		list_sum/2, list_max/2, list_min/2,	% Modern
-		list_to_set/2, length/2, reverse/2,
+		list_to_set/2, reverse/2,
 		exclude/3, include/3, permutation/2,
 		foldl/4, foldl/5, foldl/6,
 		maplist/2, maplist/3, maplist/4, maplist/5, maplist/6, maplist/7, maplist/8,
@@ -297,46 +297,6 @@ is_set(Set) :-
 	length(Sorted, Len)
   .
 :- help(is_set(+list), [iso(false), desc('Is it a set.')]).
-
-length(Xs0, N) :-
-   '$skip_max_list'(M, N, Xs0,Xs),
-   !,
-   (  Xs == [] -> N = M
-   ;  nonvar(Xs) -> var(N), Xs = [_|_], resource_error(finite_memory,length/2)
-   ;  nonvar(N) -> R is N-M, length_rundown(Xs, R)
-   ;  N == Xs -> failingvarskip(Xs), resource_error(finite_memory,length/2)
-   ;  length_addendum(Xs, N, M)
-   ).
-length(_, N) :-
-   integer(N), !,
-   domain_error(not_less_than_zero, N, length/2).
-length(_, N) :-
-   type_error(integer, N, length/2).
-
-length_rundown(Xs, 0) :- !, Xs = [].
-length_rundown(Vs, N) :-
-    '$unattributed_var'(Vs), % unconstrained
-    !,
-    '$det_length_rundown'(Vs, N).
-length_rundown([_|Xs], N) :- % force unification
-    N1 is N-1,
-    length(Xs, N1). % maybe some new info on Xs
-
-failingvarskip(Xs) :-
-    '$unattributed_var'(Xs), % unconstrained
-    !.
-failingvarskip([_|Xs0]) :- % force unification
-    '$skip_max_list'(_, _, Xs0,Xs),
-    (  nonvar(Xs) -> Xs = [_|_]
-	 ;  failingvarskip(Xs)
-    ).
-
-length_addendum([], N, N).
-length_addendum([_|Xs], N, M) :-
-    M1 is M + 1,
-    length_addendum(Xs, N, M1).
-
-:- help(length(?term,?integer), [iso(false), desc('Number of elements in list.')]).
 
 list_first_rest([L|Ls], L, Ls).
 

--- a/src/bif_control.c
+++ b/src/bif_control.c
@@ -855,7 +855,7 @@ static bool find_exception_handler(query *q, char *ball)
 	} else {
 		q->ball = clone_term_to_heap(q, e, e_ctx);
 		q->ball_ctx = q->st.cur_ctx;
-		rebase_term(q, q->ball, 0);
+		rebase_term(q, q->ball, 0, false);
 	}
 
 	if (!q->thread_ptr) {

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -80,8 +80,9 @@ static bool bif_clause_3(query *q)
 
 		cell *c = cl->cells;
 		cell *tmp = alloc_heap(q, c->num_cells);
+		CHECKED(tmp);
 		dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
-		rebase_term(q, tmp, f->actual_slots);
+		rebase_term(q, tmp, f->actual_slots, false);
 		cell *body = get_body(tmp);
 		bool ok;
 

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -298,11 +298,11 @@ static bool bif_iso_retractall_1(query *q)
 		return true;
 
 	prolog_lock(q->pl);
-	q->in_retractall = true;
+	q->in_retract = true;
 
 	while (do_retract(q, p1, p1_ctx, DO_RETRACTALL)) {
 		if (q->did_throw) {
-			q->in_retractall = false;
+			q->in_retract = false;
 			prolog_unlock(q->pl);
 			return true;
 		}
@@ -312,7 +312,7 @@ static bool bif_iso_retractall_1(query *q)
 		retry_choice(q);
 	}
 
-	q->in_retractall = false;
+	q->in_retract = false;
 	pr->is_processed = false;
 	prolog_unlock(q->pl);
 	return true;

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -42,6 +42,8 @@ static bool bif_clause_3(query *q)
 	if (is_var(p1) && is_var(p2) && is_var(p3))
 		return throw_error(q, p3, p3_ctx, "instantiation_error", "args_not_sufficiently_instantiated");
 
+	const frame *f = GET_CURR_FRAME();
+
 	for (;;) {
 		clause *cl;
 
@@ -76,11 +78,16 @@ static bool bif_clause_3(query *q)
 			cl = &q->st.dbe->cl;
 		}
 
-		cell *body = get_body(cl->cells);
+		cell *c = cl->cells;
+		cell *tmp = alloc_heap(q, c->num_cells);
+		dup_cells(tmp, c, c->num_cells);
+		convert_to_refs(tmp, q->st.cur_ctx, c->num_cells);
+		rebase_term(q, tmp, f->actual_slots);
+		cell *body = get_body(tmp);
 		bool ok;
 
 		if (body)
-			ok = unify(q, p2, p2_ctx, body, q->st.fp);
+			ok = unify(q, p2, p2_ctx, body, q->st.cur_ctx);
 		else {
 			cell tmp;
 			make_instr(&tmp, g_true_s, bif_iso_true_0, 0, 0);
@@ -94,6 +101,11 @@ static bool bif_clause_3(query *q)
 				last_match = !has_next_key(q);
 			} else {
 				last_match = true;
+			}
+
+			if (last_match) {
+				leave_predicate(q, q->st.pr, true);
+				drop_choice(q);
 			}
 
 			return true;

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -64,7 +64,7 @@ static bool bif_clause_3(query *q)
 				break;
 			}
 		} else {
-			if (match_clause(q, p1, p1_ctx, DO_CLAUSE) != true)
+			if (match_clause(q, p1, p1_ctx, NULL, DO_CLAUSE) != true)
 				break;
 
 			char tmpbuf[128];
@@ -96,7 +96,6 @@ static bool bif_clause_3(query *q)
 				last_match = true;
 			}
 
-			stash_frame(q, cl->num_vars, last_match);
 			return true;
 		}
 
@@ -152,14 +151,23 @@ static bool bif_iso_clause_2(query *q)
 	if (!module_context(q, &p1, p1_ctx))
 		return false;
 
-	while (match_clause(q, p1, p1_ctx, DO_CLAUSE)) {
+	cell *body;
+
+	while (match_clause(q, p1, p1_ctx, &body, DO_CLAUSE)) {
 		if (q->did_throw) return true;
-		clause *cl = &q->st.dbe->cl;
-		cell *body = get_body(cl->cells);
 		bool ok;
 
+#if 1
+		if (is_var(p2)) {
+			const frame *f = GET_FRAME(p2_ctx);
+			slot *e = get_slot(q, f, p2->var_num);
+			cell *p2_attrs = e->c.val_attrs;
+			if (p2_attrs) printf("*** attrs2 var_num=%u, var_ctx=%u\n", p2->var_num, p2_ctx);
+		}
+#endif
+
 		if (body) {
-			ok = unify(q, p2, p2_ctx, body, q->st.fp);
+			ok = unify(q, p2, p2_ctx, body, q->st.cur_ctx);
 		} else {
 			cell tmp;
 			make_instr(&tmp, g_true_s, bif_iso_true_0, 0, 0);
@@ -168,7 +176,12 @@ static bool bif_iso_clause_2(query *q)
 
 		if (ok) {
 			bool last_match = !has_next_key(q);
-			stash_frame(q, cl->num_vars, last_match);
+
+			if (last_match) {
+				leave_predicate(q, q->st.pr, true);
+				drop_choice(q);
+			}
+
 			return true;
 		}
 
@@ -216,7 +229,7 @@ bool do_retract(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 		match = match_rule(q, p1, p1_ctx, is_retract);
 	} else {
 		p1 = get_head(p1);
-		match = match_clause(q, p1, p1_ctx, is_retract);
+		match = match_clause(q, p1, p1_ctx, NULL, is_retract);
 	}
 
 	if (!match || q->did_throw)
@@ -226,9 +239,14 @@ bool do_retract(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 	db_log(q, r, LOG_ERASE);
 	retract_from_db(r->owner->m, r);
 	bool last_match = (is_retract == DO_RETRACT) && !has_next_key(q);
-	q->in_retract = true;
-	stash_frame(q, r->cl.num_vars, last_match);
-	q->in_retract = false;
+
+	if (last_match) {
+		q->in_retract = true;
+		leave_predicate(q, q->st.pr, true);
+		q->in_retract = false;
+		drop_choice(q);
+	}
+
 	return true;
 }
 

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -61,7 +61,7 @@ static bool bif_clause_3(query *q)
 			cl = &r->cl;
 			cell *head = get_head(cl->cells);
 
-			if (!unify(q, p1, p1_ctx, head, q->st.fp)) {
+			if (!unify(q, p1, p1_ctx, head, q->st.fp)) {	// FIXME: cur_ctx
 				drop_choice(q);
 				break;
 			}

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -80,8 +80,7 @@ static bool bif_clause_3(query *q)
 
 		cell *c = cl->cells;
 		cell *tmp = alloc_heap(q, c->num_cells);
-		dup_cells(tmp, c, c->num_cells);
-		convert_to_refs(tmp, q->st.cur_ctx, c->num_cells);
+		dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
 		rebase_term(q, tmp, f->actual_slots);
 		cell *body = get_body(tmp);
 		bool ok;

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -56,7 +56,6 @@ static bool bif_clause_3(query *q)
 				break;
 
 			CHECKED(push_choice(q));
-
 			q->st.dbe = r;
 			cl = &r->cl;
 			cell *c = cl->cells;
@@ -173,15 +172,6 @@ static bool bif_iso_clause_2(query *q)
 	while (match_clause(q, p1, p1_ctx, &body, DO_CLAUSE)) {
 		if (q->did_throw) return true;
 		bool ok;
-
-#if 1
-		if (is_var(p2)) {
-			const frame *f = GET_FRAME(p2_ctx);
-			slot *e = get_slot(q, f, p2->var_num);
-			cell *p2_attrs = e->c.val_attrs;
-			if (p2_attrs) printf("*** attrs2 var_num=%u, var_ctx=%u\n", p2->var_num, p2_ctx);
-		}
-#endif
 
 		if (body) {
 			ok = unify(q, p2, p2_ctx, body, q->st.cur_ctx);

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -59,9 +59,14 @@ static bool bif_clause_3(query *q)
 
 			q->st.dbe = r;
 			cl = &r->cl;
-			cell *head = get_head(cl->cells);
+			cell *c = cl->cells;
+			cell *tmp = alloc_heap(q, c->num_cells);
+			CHECKED(tmp);
+			dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
+			rebase_term(q, tmp, f->actual_slots, false);
+			cell *head = get_head(tmp);
 
-			if (!unify(q, p1, p1_ctx, head, q->st.fp)) {	// FIXME: cur_ctx
+			if (!unify(q, p1, p1_ctx, head, q->st.cur_ctx)) {
 				drop_choice(q);
 				break;
 			}

--- a/src/bif_database.c
+++ b/src/bif_database.c
@@ -240,8 +240,8 @@ bool do_retract(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 	if (is_a_rule(p1) && get_logical_body(p1)) {
 		match = match_rule(q, p1, p1_ctx, is_retract);
 	} else {
-		p1 = get_head(p1);
-		match = match_clause(q, p1, p1_ctx, NULL, is_retract);
+		cell *head = get_head(p1);
+		match = match_clause(q, head, p1_ctx, NULL, is_retract);
 	}
 
 	if (!match || q->did_throw)

--- a/src/bif_streams.c
+++ b/src/bif_streams.c
@@ -863,7 +863,7 @@ static bool bif_iso_stream_property_2(query *q)
 	CHECKED(tmp);
 	tmp->val_off = g_sys_stream_property_s;
 
-	if (match_clause(q, tmp, q->st.cur_ctx, DO_CLAUSE) != true) {
+	if (match_clause(q, tmp, q->st.cur_ctx, NULL, DO_CLAUSE) != true) {
 		clear_streams_properties(q);
 
 		if (is_callable(p1) && !strstr(s_properties, C_STR(q, p1)))
@@ -872,10 +872,8 @@ static bool bif_iso_stream_property_2(query *q)
 		return false;
 	}
 
-	clause *cl = &q->st.dbe->cl;
 	GET_FIRST_ARG(pstrx,any);
 	pstrx->flags |= FLAG_INT_STREAM;
-	stash_frame(q, cl->num_vars, false);
 	return true;
 }
 

--- a/src/bif_threads.c
+++ b/src/bif_threads.c
@@ -488,11 +488,6 @@ static bool do_match_message(query *q, unsigned chan, bool is_peek)
 				}
 
 				drop_choice(q);
-
-#if 0
-				frame *f = GET_NEW_FRAME();
-				stash_frame(q, f->actual_slots, false);
-#endif
 				return true;
 			}
 

--- a/src/bif_threads.c
+++ b/src/bif_threads.c
@@ -375,7 +375,7 @@ static bool do_send_message(query *q, unsigned chan, cell *p1, pl_ctx p1_ctx, bo
 	CHECKED(init_tmp_heap(q));
 	cell *tmp = clone_term_to_tmp(q, p1, p1_ctx);
 	CHECKED(tmp);
-	rebase_term(q, tmp, 0);
+	rebase_term(q, tmp, 0, false);
 	CHECKED(queue_to_chan(q->pl, chan, tmp, q->my_chan, is_signal));
 	resume_thread(t);
 	return true;
@@ -835,7 +835,7 @@ static bool bif_thread_create_3(query *q)
 	CHECKED(init_tmp_heap(q));
 	cell *tmp = clone_term_to_tmp(q, p1, p1_ctx);
 	CHECKED(tmp);
-	t->num_vars = rebase_term(q, tmp, 0);
+	t->num_vars = rebase_term(q, tmp, 0, false);
 	t->q = query_create_threaded(q->st.m);
 	CHECKED(t->q);
 	t->q->thread_ptr = t;
@@ -852,7 +852,7 @@ static bool bif_thread_create_3(query *q)
 		CHECKED(init_tmp_heap(q));
 		cell *tmp = clone_term_to_tmp(q, exit_goal, exit_goal_ctx);
 		CHECKED(tmp);
-		t->at_exit_goal_num_vars = rebase_term(q, tmp, 0);
+		t->at_exit_goal_num_vars = rebase_term(q, tmp, 0, false);
 		cell *tmp2 = alloc_heap(q, 1+tmp->num_cells+1);
 		CHECKED(tmp2);
 		pl_idx num_cells = 0;
@@ -1162,7 +1162,7 @@ static bool bif_thread_exit_1(query *q)
 	CHECKED(init_tmp_heap(q));
 	cell *tmp = clone_term_to_tmp(q, p1, p1_ctx);
 	CHECKED(tmp);
-	rebase_term(q, tmp, 0);
+	rebase_term(q, tmp, 0, false);
 	cell *tmp2 = TPL_calloc(1+tmp->num_cells, sizeof(cell));
 	CHECKED(tmp2);
 	make_instr(tmp2, new_atom(q->pl, "exited"), NULL, 1, tmp->num_cells);

--- a/src/heap.c
+++ b/src/heap.c
@@ -282,6 +282,18 @@ static bool copy_vars(query *q, cell *c, bool copy_attrs, cell *from, pl_ctx fro
 	return true;
 }
 
+void convert_to_refs(cell *c, pl_ctx c_ctx, unsigned num_cells)
+{
+	while (num_cells--) {
+		if (is_var(c) && !is_ref(c)) {
+			c->flags |= FLAG_VAR_REF;
+			c->val_ctx = c_ctx;
+		}
+
+		c++;
+	}
+}
+
 unsigned rebase_term(query *q, cell *c, unsigned start_nbr)
 {
 	q->vars = NULL;

--- a/src/heap.c
+++ b/src/heap.c
@@ -239,7 +239,7 @@ static bool copy_vars(query *q, cell *c, bool copy_attrs, cell *from, pl_ctx fro
 		} else {
 			const frame *f = GET_FRAME(c->val_ctx);
 			const slot *e = get_slot(q, f, c->var_num);
-			cell *attrs = c->tmp_attrs ? c->tmp_attrs : e->c.val_attrs;
+			cell *attrs = copy_attrs && c->tmp_attrs ? c->tmp_attrs : e->c.val_attrs;
 			const size_t slot_nbr = get_ordered_slot_num(q, f, c->var_num);
 			int var_num;
 
@@ -282,13 +282,13 @@ static bool copy_vars(query *q, cell *c, bool copy_attrs, cell *from, pl_ctx fro
 	return true;
 }
 
-unsigned rebase_term(query *q, cell *c, unsigned start_nbr)
+unsigned rebase_term(query *q, cell *c, unsigned start_nbr, bool copy_attrs)
 {
 	q->vars = NULL;
 	q->varno = start_nbr;
 	q->tab_idx = 0;
 
-	if (!copy_vars(q, c, true, NULL, 0, NULL, 0)) {
+	if (!copy_vars(q, c, copy_attrs, NULL, 0, NULL, 0)) {
 		if (q->vars)
 			sl_destroy(q->vars);
 
@@ -346,7 +346,7 @@ static cell *copy_term_to_tmp_with_replacement(query *q, cell *p1, pl_ctx p1_ctx
 	c = tmp;
 
 	for (pl_idx i = 0; i < tmp->num_cells; i++, c++) {
-		if (is_var(c) && c->tmp_attrs) {
+		if (is_var(c) && copy_attrs && c->tmp_attrs) {
 			const frame *f = GET_FRAME(c->val_ctx);
 			slot *e = get_slot(q, f, c->var_num);
 			e->c.val_attrs = c->tmp_attrs;
@@ -449,7 +449,7 @@ cell *copy_term_to_heap_with_replacement(query *q, cell *p1, pl_ctx p1_ctx, bool
 	cell *c = tmp2;
 
 	for (pl_idx i = 0; i < tmp2->num_cells; i++, c++) {
-		if (is_var(c) && c->tmp_attrs) {
+		if (is_var(c) && copy_attrs && c->tmp_attrs) {
 			const frame *f = GET_FRAME(c->val_ctx);
 			slot *e = get_slot(q, f, c->var_num);
 			e->c.val_attrs = c->tmp_attrs;
@@ -478,7 +478,7 @@ cell *copy_term_to_heap(query *q, cell *p1, pl_ctx p1_ctx, bool copy_attrs)
 	cell *c = tmp2;
 
 	for (pl_idx i = 0; i < tmp2->num_cells; i++, c++) {
-		if (is_var(c) && c->tmp_attrs) {
+		if (is_var(c) && copy_attrs && c->tmp_attrs) {
 			const frame *f = GET_FRAME(c->val_ctx);
 			slot *e = get_slot(q, f, c->var_num);
 			e->c.val_attrs = c->tmp_attrs;

--- a/src/heap.c
+++ b/src/heap.c
@@ -282,18 +282,6 @@ static bool copy_vars(query *q, cell *c, bool copy_attrs, cell *from, pl_ctx fro
 	return true;
 }
 
-void convert_to_refs(cell *c, pl_ctx c_ctx, unsigned num_cells)
-{
-	while (num_cells--) {
-		if (is_var(c) && !is_ref(c)) {
-			c->flags |= FLAG_VAR_REF;
-			c->val_ctx = c_ctx;
-		}
-
-		c++;
-	}
-}
-
 unsigned rebase_term(query *q, cell *c, unsigned start_nbr)
 {
 	q->vars = NULL;

--- a/src/heap.c
+++ b/src/heap.c
@@ -293,13 +293,13 @@ unsigned rebase_term(query *q, cell *c, unsigned start_nbr, bool copy_attrs)
 			sl_destroy(q->vars);
 
 		q->vars = NULL;
-		return start_nbr;
+		return q->varno;
 	}
 
-	if (q->vars)
+	if (q->vars) {
 		sl_destroy(q->vars);
-
-	q->vars = NULL;
+		q->vars = NULL;
+	}
 
 	// Turn refs back into vars to recontextualize
 

--- a/src/heap.h
+++ b/src/heap.h
@@ -24,6 +24,7 @@ cell *alloc_queuen(query *q, unsigned qnum, const cell *c);
 
 void fix_list(cell *c);
 unsigned rebase_term(query *q, cell *c, unsigned start_nbr);
+void convert_to_refs(cell *c, pl_ctx c_ctx, unsigned num_cells);
 
 // These allocate on the heap...
 

--- a/src/heap.h
+++ b/src/heap.h
@@ -23,7 +23,7 @@ void trim_heap(query *q);
 cell *alloc_queuen(query *q, unsigned qnum, const cell *c);
 
 void fix_list(cell *c);
-unsigned rebase_term(query *q, cell *c, unsigned start_nbr);
+unsigned rebase_term(query *q, cell *c, unsigned start_nbr, bool copy_attrs);
 
 // These allocate on the heap...
 

--- a/src/heap.h
+++ b/src/heap.h
@@ -24,7 +24,6 @@ cell *alloc_queuen(query *q, unsigned qnum, const cell *c);
 
 void fix_list(cell *c);
 unsigned rebase_term(query *q, cell *c, unsigned start_nbr);
-void convert_to_refs(cell *c, pl_ctx c_ctx, unsigned num_cells);
 
 // These allocate on the heap...
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -755,7 +755,6 @@ struct query_ {
 	bool end_wait:1;
 	bool did_unhandled_exception:1;
 	bool access_private:1;
-	bool in_retractall:1;
 	bool in_retract:1;
 };
 

--- a/src/internal.h
+++ b/src/internal.h
@@ -725,7 +725,6 @@ struct query_ {
 	bool portray_vars:1;
 	bool status:1;
 	bool no_recov:1;
-	bool no_recov_compound:1;
 	bool has_vars:1;
 	bool error:1;
 	bool did_throw:1;

--- a/src/query.c
+++ b/src/query.c
@@ -1390,8 +1390,8 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 
 		cell *tmp = alloc_heap(q, c->num_cells);
 		dup_cells(tmp, c, c->num_cells);
-		create_vars(q, cl->num_vars);
-		rebase_term(q, c, f->actual_slots);
+		convert_to_refs(tmp, q->st.cur_ctx, c->num_cells);
+		rebase_term(q, tmp, f->actual_slots);
 		c = tmp;
 		cell *head = get_head(c);
 		const cell *c_body = get_logical_body(c);

--- a/src/query.c
+++ b/src/query.c
@@ -533,11 +533,6 @@ void leave_predicate(query *q, predicate *pr, bool is_final)
 			}
 		}
 
-		// Just because this clause is no longer in use doesn't
-		// mean there are no shared references to terms contained
-		// within. So may have to move to the query dirty-list where
-		// they will be freed up at end of the query...
-
 		if (q->in_retractall && !pr->cnt
 			&& !r->cl.num_vars
 			&& q->pl->opt) {

--- a/src/query.c
+++ b/src/query.c
@@ -804,33 +804,6 @@ static void commit_frame(query *q)
 	q->st.iter = NULL;
 }
 
-void stash_frame(query *q, unsigned num_vars, bool last_match)
-{
-	pl_idx chgen = ++q->chgen;
-
-	if (last_match) {
-		leave_predicate(q, q->st.pr, true);
-		drop_choice(q);
-	} else {
-		choice *ch = GET_CURR_CHOICE();
-		ch->st.dbe = q->st.dbe;
-		ch->gen = chgen;
-	}
-
-	if (num_vars) {
-		frame *f = GET_FRAME(q->st.fp);
-		f->prev = q->st.cur_ctx;
-		f->instr = NULL;
-		f->chgen = chgen;
-		f->frame_size = 1;
-		f->op = 0;
-		q->st.sp += num_vars;
-		q->st.fp += f->frame_size;
-	}
-
-	q->st.iter = NULL;
-}
-
 int retry_choice(query *q)
 {
 	while (q->cp) {

--- a/src/query.c
+++ b/src/query.c
@@ -543,11 +543,6 @@ void leave_predicate(query *q, predicate *pr, bool is_final)
 			&& q->pl->opt) {
 			clear_clause(&r->cl);
 			TPL_free(r);
-		} else if (q->in_retract && (q->retry == QUERY_RETRY)
-			&& !r->cl.num_vars
-			&& q->pl->opt) {
-			clear_clause(&r->cl);
-			TPL_free(r);
 		} else if (q->in_retract
 			&& !r->cl.num_vars
 			&& q->pl->opt) {

--- a/src/query.c
+++ b/src/query.c
@@ -533,14 +533,7 @@ void leave_predicate(query *q, predicate *pr, bool is_final)
 			}
 		}
 
-		if (q->in_retractall
-			&& !r->cl.num_vars
-			&& q->pl->opt) {
-			clear_clause(&r->cl);
-			TPL_free(r);
-		} else if (q->in_retract
-			&& !r->cl.num_vars
-			&& q->pl->opt) {
+		if (q->in_retract && !r->cl.num_vars && q->pl->opt) {
 			clear_clause(&r->cl);
 			TPL_free(r);
 		} else {

--- a/src/query.c
+++ b/src/query.c
@@ -1456,7 +1456,7 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **ret_body, enum claus
 
 		// retract(HEAD) should ignore rules (and directives)
 
-		if ((is_retract == DO_RETRACT) && body)	// FIXME: and retractall as well?
+		if ((is_retract == DO_RETRACT) && body)
 			continue;
 
 		CHECKED(push_choice(q));

--- a/src/query.c
+++ b/src/query.c
@@ -1389,8 +1389,9 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 		p1 = orig_p1;
 
 		cell *tmp = alloc_heap(q, c->num_cells);
+		CHECKED(tmp);
 		dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
-		rebase_term(q, tmp, f->actual_slots);
+		rebase_term(q, tmp, f->actual_slots, false);
 		c = tmp;
 		cell *head = get_head(c);
 		const cell *c_body = get_logical_body(c);
@@ -1504,8 +1505,9 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **ret_body, enum claus
 
 		CHECKED(push_choice(q));
 		cell *tmp = alloc_heap(q, c->num_cells);
+		CHECKED(tmp);
 		dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
-		rebase_term(q, tmp, f->actual_slots);
+		rebase_term(q, tmp, f->actual_slots, false);
 		cell *head = get_head(tmp);
 		body = get_body(tmp);
 

--- a/src/query.c
+++ b/src/query.c
@@ -1389,8 +1389,7 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 		p1 = orig_p1;
 
 		cell *tmp = alloc_heap(q, c->num_cells);
-		dup_cells(tmp, c, c->num_cells);
-		convert_to_refs(tmp, q->st.cur_ctx, c->num_cells);
+		dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
 		rebase_term(q, tmp, f->actual_slots);
 		c = tmp;
 		cell *head = get_head(c);
@@ -1505,8 +1504,7 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **ret_body, enum claus
 
 		CHECKED(push_choice(q));
 		cell *tmp = alloc_heap(q, c->num_cells);
-		dup_cells(tmp, c, c->num_cells);
-		convert_to_refs(tmp, q->st.cur_ctx, c->num_cells);
+		dup_cells_by_ref(tmp, c, q->st.cur_ctx, c->num_cells);
 		rebase_term(q, tmp, f->actual_slots);
 		cell *head = get_head(tmp);
 		body = get_body(tmp);

--- a/src/query.c
+++ b/src/query.c
@@ -1456,7 +1456,7 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **ret_body, enum claus
 
 		// retract(HEAD) should ignore rules (and directives)
 
-		if ((is_retract == DO_RETRACT) && body)
+		if ((is_retract == DO_RETRACT) && body)	// FIXME: and retractall as well?
 			continue;
 
 		CHECKED(push_choice(q));

--- a/src/query.c
+++ b/src/query.c
@@ -238,7 +238,7 @@ bool check_frame(query *q, unsigned max_vars)
 
 bool check_slot(query *q, unsigned cnt)
 {
-	cnt += 1024;	// Why??
+	cnt += 2;	// Allow some extra
 
 	pl_idx num = q->st.sp + cnt;
 

--- a/src/query.c
+++ b/src/query.c
@@ -549,7 +549,6 @@ void leave_predicate(query *q, predicate *pr, bool is_final)
 			clear_clause(&r->cl);
 			TPL_free(r);
 		} else if (q->in_retract
-			&& !q->no_recov_compound
 			&& !r->cl.num_vars
 			&& q->pl->opt) {
 			clear_clause(&r->cl);
@@ -1375,8 +1374,6 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 		return false;
 	}
 
-	CHECKED(check_frame(q, q->st.pr->max_vars));
-	CHECKED(push_choice(q));
 	const frame *f = GET_CURR_FRAME();
 	cell *p1_body = deref(q, get_logical_body(p1), p1_ctx);
 	cell *orig_p1 = p1;
@@ -1385,21 +1382,27 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 		if (!can_view(q, f->dbgen, q->st.dbe))
 			continue;
 
+		CHECKED(push_choice(q));
 		clause *cl = &q->st.dbe->cl;
 		cell *c = cl->cells;
 		bool needs_true = false;
 		p1 = orig_p1;
+
+		cell *tmp = alloc_heap(q, c->num_cells);
+		dup_cells(tmp, c, c->num_cells);
+		create_vars(q, cl->num_vars);
+		rebase_term(q, c, f->actual_slots);
+		c = tmp;
+		cell *head = get_head(c);
 		const cell *c_body = get_logical_body(c);
 
 		if (p1_body && is_var(p1_body) && !c_body) {
 			p1 = deref(q, get_head(p1), p1_ctx);
-			c = get_head(c);
+			c = get_head(tmp);
 			needs_true = true;
 		}
 
-		try_me(q, cl->num_vars);
-
-		if (unify(q, p1, p1_ctx, c, q->st.fp)) {
+		if (unify(q, p1, p1_ctx, c, q->st.cur_ctx)) {
 			int ok;
 
 			if (needs_true) {
@@ -1414,7 +1417,7 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 			return ok;
 		}
 
-		undo_me(q);
+		retry_choice(q);
 	}
 
 	leave_predicate(q, q->st.pr, true);
@@ -1425,7 +1428,7 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
 // Match HEAD.
 // Match HEAD :- true.
 
-bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract)
+bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **ret_body, enum clause_type is_retract)
 {
 	if (!q->retry) {
 		cell *c = p1;
@@ -1485,8 +1488,6 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract
 		return false;
 	}
 
-	CHECKED(check_frame(q, q->st.pr->max_vars));
-	CHECKED(push_choice(q));
 	const frame *f = GET_CURR_FRAME();
 
 	for (; q->st.dbe; q->st.dbe = q->st.dbe->next) {
@@ -1494,24 +1495,33 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract
 			continue;
 
 		clause *cl = &q->st.dbe->cl;
-		cell *head = get_head(cl->cells);
-		const cell *body = get_logical_body(cl->cells);
+		cell *c = cl->cells;
+		cell *body = get_logical_body(c);
 
 		// retract(HEAD) should ignore rules (and directives)
 
 		if ((is_retract == DO_RETRACT) && body)
 			continue;
 
-		try_me(q, cl->num_vars);
+		CHECKED(push_choice(q));
+		cell *tmp = alloc_heap(q, c->num_cells);
+		dup_cells(tmp, c, c->num_cells);
+		create_vars(q, cl->num_vars);
+		rebase_term(q, tmp, f->actual_slots);
+		cell *head = get_head(tmp);
+		body = get_body(tmp);
 
-		if (unify(q, p1, p1_ctx, head, q->st.fp))
+		if (unify(q, p1, p1_ctx, head, q->st.cur_ctx)) {
+			if (ret_body)
+				*ret_body = body;
+
 			return true;
+		}
 
-		undo_me(q);
+		retry_choice(q);
 	}
 
 	leave_predicate(q, q->st.pr, true);
-	drop_choice(q);
 	return false;
 }
 

--- a/src/query.c
+++ b/src/query.c
@@ -1506,7 +1506,7 @@ bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **ret_body, enum claus
 		CHECKED(push_choice(q));
 		cell *tmp = alloc_heap(q, c->num_cells);
 		dup_cells(tmp, c, c->num_cells);
-		create_vars(q, cl->num_vars);
+		convert_to_refs(tmp, q->st.cur_ctx, c->num_cells);
 		rebase_term(q, tmp, f->actual_slots);
 		cell *head = get_head(tmp);
 		body = get_body(tmp);

--- a/src/query.c
+++ b/src/query.c
@@ -533,7 +533,7 @@ void leave_predicate(query *q, predicate *pr, bool is_final)
 			}
 		}
 
-		if (q->in_retractall && !pr->cnt
+		if (q->in_retractall
 			&& !r->cl.num_vars
 			&& q->pl->opt) {
 			clear_clause(&r->cl);

--- a/src/query.h
+++ b/src/query.h
@@ -43,7 +43,7 @@ int retry_choice(query *q);
 void assign_vars(parser *p, unsigned start, bool rebase);
 bool start(query *q);
 bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract);
-bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type retract);
+bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **body, enum clause_type retract);
 void try_me(query *q, unsigned vars);
 void call_attrs(query *q, cell *attrs);
 void stash_frame(query *q, unsigned num_vars, bool last_match);

--- a/src/query.h
+++ b/src/query.h
@@ -46,7 +46,6 @@ bool match_rule(query *q, cell *p1, pl_ctx p1_ctx, enum clause_type is_retract);
 bool match_clause(query *q, cell *p1, pl_ctx p1_ctx, cell **body, enum clause_type retract);
 void try_me(query *q, unsigned vars);
 void call_attrs(query *q, cell *attrs);
-void stash_frame(query *q, unsigned num_vars, bool last_match);
 bool check_redo(query *q);
 void dump_vars(query *q, bool partial);
 int check_interrupt(query *q);

--- a/src/unify.c
+++ b/src/unify.c
@@ -265,7 +265,6 @@ static void set_var(query *q, const cell *c, pl_ctx c_ctx, cell *v, pl_ctx v_ctx
 		}
 	} else if (is_compound(v)) {
 		make_indirect(&e->c, v, v_ctx);
-		q->no_recov_compound = true;
 
 		if ((v_ctx >= q->st.cur_ctx)
 			&& !is_ground(v)
@@ -609,7 +608,8 @@ static bool unify_internal(query *q, cell *p1, pl_ctx p1_ctx, cell *p2, pl_ctx p
 bool unify(query *q, cell *p1, pl_ctx p1_ctx, cell *p2, pl_ctx p2_ctx)
 {
 	q->is_cyclic1 = q->is_cyclic2 = false;
-	q->has_vars = q->no_recov = q->no_recov_compound = false;
+	q->has_vars = q->no_recov = false;
+	q->run_hook = false;
 	q->before_hook_tp = q->st.tp;
 	if (++q->vgen == 0) q->vgen = 1;
 	bool ok;

--- a/tests/issues-OLD/test074.expected
+++ b/tests/issues-OLD/test074.expected
@@ -1,6 +1,6 @@
 clause(cup(_4),(liftable(_4),holds_liquid(_4)))
 clause(liftable(_4),(light(_4),part(_4,handle)))
 clause(light(_4),small(_4))
-clause(holds_liquid(_4),(part(_4,_66),concave(_66),points_up(_66)))
+clause(holds_liquid(_4),(part(_4,_70),concave(_70),points_up(_70)))
 clause(concave(bowl),true)
-cup(_4):-(small(_4),part(_4,handle)),part(_4,_66),concave(_66),points_up(_66)
+cup(_4):-(small(_4),part(_4,handle)),part(_4,_70),concave(_70),points_up(_70)

--- a/tests/issues-OLD/test074.expected
+++ b/tests/issues-OLD/test074.expected
@@ -1,6 +1,6 @@
 clause(cup(_4),(liftable(_4),holds_liquid(_4)))
 clause(liftable(_4),(light(_4),part(_4,handle)))
 clause(light(_4),small(_4))
-clause(holds_liquid(_4),(part(_4,_70),concave(_70),points_up(_70)))
+clause(holds_liquid(_4),(part(_4,_66),concave(_66),points_up(_66)))
 clause(concave(bowl),true)
-cup(_4):-(small(_4),part(_4,handle)),part(_4,_70),concave(_70),points_up(_70)
+cup(_4):-(small(_4),part(_4,handle)),part(_4,_66),concave(_66),points_up(_66)


### PR DESCRIPTION
Should offer memory savings by eliminating stashing of database clauses in fake frames, thus allowing more TCOs. Also simplifies code.

Currently only unexpected failure is `logtalk/tests/prolog/predicates/setup_call_cleanup_3` with `swi_setup_call_cleanup_3_11`.


