### PR TITLE
fix: tpl in tpl.c

### DIFF
--- a/tpl.c
+++ b/tpl.c
@@ -58,14 +58,13 @@ static int daemonize(int argc, char *argv[])
 			watchdog = 1;
 #endif
 		} else if (!strncmp(argv[i], "--cd=", 5))
-			strcpy(path, argv[i] + 5);
+			snprintf(path, sizeof(path), "%s", argv[i] + 5);
 	}
 
 #ifdef _WIN32
 	char cmd[1024], args[1024 * 8];
 	args[0] = 0;
-	strcpy(cmd, argv[0]);
-	strcat(cmd, ".exe");
+	snprintf(cmd, sizeof(cmd), "%s.exe", argv[0]);
 
 	for (int i = 0; i < argc; i++) {
 		if (!strcmp(argv[i], "-d") || !strcmp(argv[i], "--daemon"))


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `tpl.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `tpl.c:61` |

**Description**: tpl.c copies command-line arguments into fixed-size stack buffers using strcpy without any length validation. Line 61 copies argv[i]+5 into 'path' and lines 67-68 copy argv[0] then append '.exe' into 'cmd'. An attacker supplying an argument longer than the destination buffer overwrites adjacent stack memory including the saved return address, enabling full control flow hijacking.

## Changes
- `tpl.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
